### PR TITLE
Fix some errors in the sphinx-readthedocs configuration

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -101,7 +101,7 @@ python setup.py integrate -a "--junitxml=./path_to_outputfile.xml"
 Documentation is provided by [sphinx](http://www.sphinx-doc.org/en/stable/). To (re)build the documentation:
 
 ```
-pip install sphinx_rtd_theme ipython m2r
+pip install sphinx_rtd_theme ipython
 
 cd sphinx
 make html

--- a/requirements-python3.txt
+++ b/requirements-python3.txt
@@ -1,3 +1,4 @@
+# Requirements for the OpenOA software package
 numpy==1.15.4
 scipy==1.1.0
 pandas==0.23.4
@@ -5,9 +6,6 @@ geopandas==0.4.0
 pygam==0.8.0
 tqdm==4.28.1
 statsmodels==0.9.0
-sphinx==1.5.6
-sphinxcontrib-napoleon==0.6.1
-sphinx_rtd_theme==0.2.4
 pytest==3.4.0
 pytest-cov==2.5.1
 scikit_learn==0.20.1

--- a/requirements-python3.txt
+++ b/requirements-python3.txt
@@ -1,14 +1,16 @@
 # Requirements for the OpenOA software package
-numpy==1.15.4
-scipy==1.1.0
-pandas==0.23.4
+eia-python==1.22
 geopandas==0.4.0
+numpy==1.15.4
+pandas==0.23.4
 pygam==0.8.0
-tqdm==4.28.1
+scipy==1.1.0
 statsmodels==0.9.0
+tqdm==4.28.1
+
+# Not included in docs requirements
 pytest==3.4.0
 pytest-cov==2.5.1
 scikit_learn==0.20.1
 matplotlib==2.1.0
-eia-python==1.22
 requests==2.21.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+# Requirements for the OpenOA software package
 numpy==1.14.0
 scipy==1.0.0
 pandas==0.20.3
@@ -5,9 +6,6 @@ geopandas==0.3.0
 pygam==0.4.0
 tqdm==4.19.5
 statsmodels==0.8.0
-sphinx==1.5.6
-sphinxcontrib-napoleon==0.6.1
-sphinx_rtd_theme==0.2.4
 pytest==3.4.0
 pytest-cov==2.5.1
 scikit_learn==0.18.1

--- a/sphinx/Turbine_Toolkit_Examples.rst
+++ b/sphinx/Turbine_Toolkit_Examples.rst
@@ -9,7 +9,7 @@ this case), instantiating a project, and calling its prepare method.
 This process provides us with a PlantData object (turbine, in this case)
 which can be used to query data.
 
-.. code:: ipython2
+.. code:: python
 
     from turbine_project import TurbineExampleProject
     
@@ -105,7 +105,7 @@ of the scada TimeseriesTable exposes a Pandas dataframe which contains
 cleaned SCADA data. Let’s use turbine.scada to define python variables
 windspeed, power_kw, and df for convenience in later examples.
 
-.. code:: ipython2
+.. code:: python
 
     windspeed = turbine.scada.df["windspeed_ms"]
     power_kw = turbine.scada.df["power_kw"]
@@ -118,7 +118,7 @@ The filtering toolkit implements commonly used filters and operates by
 returning a boolean series called “flag” which can be used to index the
 original dataframe. We start by importing the filtering toolkit:
 
-.. code:: ipython2
+.. code:: python
 
     from operational_analysis.toolkits import filters
 
@@ -126,12 +126,12 @@ First let’s define a plotting function for the turbine power curve which
 we can use to examine the effect of different filtering functions on the
 data
 
-.. code:: ipython2
+.. code:: python
 
     import numpy as np
     import matplotlib.pyplot as plt
 
-.. code:: ipython2
+.. code:: python
 
     def plot_flagged_pc(ws, p, flag_bool, alpha):
         plt.scatter(ws, p, s = 1, alpha = alpha)
@@ -142,7 +142,7 @@ data
 
 Now first let’s take a look at the unprocessed data:
 
-.. code:: ipython2
+.. code:: python
 
     plot_flagged_pc(windspeed, power_kw, np.repeat('True', df.shape[0]), 1)
 
@@ -158,7 +158,7 @@ We immediately see two high wind speed outliers likely due to sensor
 malfunction. We can flag and filter these outliers from the dataset
 using the ‘range_flag’ function:
 
-.. code:: ipython2
+.. code:: python
 
     # Show outliers
     out_of_range = filters.range_flag(windspeed, below=0, above=70)
@@ -178,13 +178,13 @@ using the ‘range_flag’ function:
 
 Let’s remove the outliers and plot the result:
 
-.. code:: ipython2
+.. code:: python
 
     # Remove outliers
     windspeed = windspeed[~out_of_range]
     power_kw = power_kw[~out_of_range]
 
-.. code:: ipython2
+.. code:: python
 
     # Show updated power curve
     plot_flagged_pc(windspeed, power_kw, np.repeat('True', df.shape[0]), 0.2)
@@ -202,7 +202,7 @@ near zero power at high wind speeds. We can do this using the
 ‘window_range function’ and removing data greater than 6 m/s but with
 power less than 20 kW:
 
-.. code:: ipython2
+.. code:: python
 
     out_of_window = filters.window_range_flag(windspeed, 6., 40, power_kw, 20., 2000.)
     plot_flagged_pc(windspeed, power_kw, out_of_window, 0.2)
@@ -214,7 +214,7 @@ power less than 20 kW:
 
 Again, let’s remove these flagged data from consideration:
 
-.. code:: ipython2
+.. code:: python
 
     windspeed = windspeed[~out_of_window]
     power_kw = power_kw[~out_of_window]
@@ -237,7 +237,7 @@ threshold of 1.5 m/s from the median for each bin. Let’s also consider
 data on both sides of the curve by setting the ‘direction’ parameter to
 ‘all’
 
-.. code:: ipython2
+.. code:: python
 
     max_bin = 0.90*power_kw.max()
     bin_outliers = filters.bin_filter(power_kw, windspeed, 100, 1.5, 'median', 20., max_bin, 'scalar', 'all')
@@ -255,7 +255,7 @@ but low wind speed that weren’t flagged, however. Let catch those, and
 then remove those as well as the flagged data above, and plot our
 ‘clean’ power curve
 
-.. code:: ipython2
+.. code:: python
 
     out_of_window = filters.window_range_flag(windspeed, 4., 8., power_kw, 0., 1250.)
     windspeed = windspeed[(~out_of_window) & (~bin_outliers)]
@@ -278,7 +278,7 @@ As a final filtering demonstration, we can look for an unrespsonsive
 sensor (i.e. repeating measurements). In this case, let’s look for 3 or
 more repeating wind speed measurements:
 
-.. code:: ipython2
+.. code:: python
 
     frozen = filters.unresponsive_flag(windspeed, 3)
     windspeed[frozen].head()
@@ -301,7 +301,7 @@ more repeating wind speed measurements:
 We actually found a lot, so let’s remove these data as well before
 moving on to power curve fitting.
 
-.. code:: ipython2
+.. code:: python
 
     windspeed = windspeed[~frozen]
     power_kw = power_kw[~frozen]
@@ -314,18 +314,18 @@ curve model to the data. Here we illustrate three types of power curves:
 the standard IEC binned power curve model, a spline fit, and a Logistic
 5 parameter model (L5P):
 
-.. code:: ipython2
+.. code:: python
 
     from operational_analysis.toolkits import power_curve
 
-.. code:: ipython2
+.. code:: python
 
     # Fit the power curves
     iec_curve = power_curve.IEC(windspeed, power_kw)
     l5p_curve = power_curve.logistic_5_parametric(windspeed, power_kw)
     spline_curve = power_curve.spline_fit(windspeed, power_kw, n_splines = 20)
 
-.. code:: ipython2
+.. code:: python
 
     # Plot the results
     x = np.linspace(0,20,100)
@@ -355,11 +355,11 @@ Relative Speed of Power Curve Fitting
 We also note the speed of the computations. The IEC method is by far the
 fastest, followed by the spline fit, and then the L5P model.
 
-.. code:: ipython2
+.. code:: python
 
     import time
 
-.. code:: ipython2
+.. code:: python
 
     start = time.time()
     power_curve.IEC(windspeed, power_kw)
@@ -372,7 +372,7 @@ fastest, followed by the spline fit, and then the L5P model.
     IEC: 0.171 seconds
 
 
-.. code:: ipython2
+.. code:: python
 
     start = time.time()
     power_curve.spline_fit(windspeed, power_kw, n_splines=20)
@@ -385,7 +385,7 @@ fastest, followed by the spline fit, and then the L5P model.
     Spline: 21.586 seconds
 
 
-.. code:: ipython2
+.. code:: python
 
     start = time.time()
     power_curve.logistic_5_parametric(windspeed, power_kw)

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -35,7 +35,8 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.ifconfig',
               'sphinx.ext.viewcode',
               'sphinx.ext.napoleon',
-              'sphinx.ext.todo']
+              'sphinx.ext.todo',
+              'm2r']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -35,8 +35,7 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.ifconfig',
               'sphinx.ext.viewcode',
               'sphinx.ext.napoleon',
-              'sphinx.ext.todo',
-              'm2r']
+              'sphinx.ext.todo']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/sphinx/operational_AEP_analysis.rst
+++ b/sphinx/operational_AEP_analysis.rst
@@ -23,7 +23,7 @@ in the ‘examples/operational_AEP_analysis/data’ folder or in
 ‘examples/operational_AEP_analysis/data/example_eia_data’ depending on
 how the zip file was unzipped.
 
-.. code:: ipython2
+.. code:: python
 
     # Import required packages
     import os
@@ -48,12 +48,12 @@ In the call below, make sure the appropriate path to the CSV input files
 is specfied. In this example, the CSV files are located directly in the
 ‘examples/operational_AEP_analysis/data’ folder.
 
-.. code:: ipython2
+.. code:: python
 
     # Load plant object
     project = Project_EIA('./data')
 
-.. code:: ipython2
+.. code:: python
 
     # Prepare data
     project.prepare()
@@ -76,7 +76,7 @@ individually by removing the first ‘#’ or comment sign from one of the
 lines below. As an example, the first few rows of the meter data is
 shown below:
 
-.. code:: ipython2
+.. code:: python
 
     # Review plant data
     project._meter.df.head() # Metered energy data
@@ -156,7 +156,7 @@ The raw plant data can be in different time resolutions. The following
 steps process the data into monthly averages and combine them into a
 single ‘monthly’ data frame to be used in the OA assessment.
 
-.. code:: ipython2
+.. code:: python
 
     # Create plant analysis object
     pa = plant_analysis.PlantAnalysis(project)
@@ -180,7 +180,7 @@ of days in the month (useful for normalizing monthly gross energy later)
 - num_days_actual : actual number of days per month as found in the data
 (used when trimming monthly data frame)
 
-.. code:: ipython2
+.. code:: python
 
     # View the monthly data frame
     pa._monthly.df.head()
@@ -374,7 +374,7 @@ good first look at data quality.
 The plot shows that 3 of the reanalysis products track each other
 reasonably well and seem well-suited for the analysis.
 
-.. code:: ipython2
+.. code:: python
 
     # Make a plot of annual average wind speeds from reanalysis data to show general trends for each
     # Remove data with incomplete years
@@ -420,7 +420,7 @@ The plots below reveal that: - there are a large number of outliers
 (typical of EIA data) - All renalysis products are strongly correlated
 with plant energy
 
-.. code:: ipython2
+.. code:: python
 
     ## Make a plot of normalized 30-day gross energy vs wind speed for each reanalysis product, include R2 measure
     valid_monthly=pa._monthly.df
@@ -454,7 +454,7 @@ Next we show time series plots of the monthly gross energy, availabilty,
 and curtialment. Note the randomness of the availability and curtailment
 data, which were in fact randomly generated.
 
-.. code:: ipython2
+.. code:: python
 
     plt.figure(figsize=(15,22))
     
@@ -506,7 +506,7 @@ example, if a high-loss month is found, reasons for the high loss should
 be discussed with the owner/operator to determine if those losses can be
 considered representative of average plant operation.
 
-.. code:: ipython2
+.. code:: python
 
     # For illustrative purposes, let's suppose a few months aren't representative of long-term losses
     pa._monthly.df.loc['2016-11-01',['availability_typical','curtailment_typical']] = False
@@ -520,7 +520,7 @@ and curtailment losses for the plant are calculated based on average
 losses for each calendar month (in energy units). Summing those average
 values yields the long-term annual estimates.
 
-.. code:: ipython2
+.. code:: python
 
     pa.calculate_long_term_losses()
 
@@ -532,7 +532,7 @@ trend and relationship with plant energy), we now set which reanalysis
 products we will include in the OA. For this particular case study, we
 use all 3 products given the high regression relationships.
 
-.. code:: ipython2
+.. code:: python
 
     # Based on the above considerations, determine which reanalysis products should be used in assesing operational AEP
     valid_reanalysis={'ncep2':True,'erai':True,'merra2':True}
@@ -616,7 +616,7 @@ More detailed descriptions are provided below:
    iteration of the OA code, one of the reanalysis products that we’ve
    already determined as valid (see the cells above) is selected.
 
-.. code:: ipython2
+.. code:: python
 
     # Get distribution of AEP values by running the OA multiple times under a Monte Carlo approach
     num_sim = 20000 # Number of simulations
@@ -655,7 +655,7 @@ monthly average wind speeds to calculate long-term monthly gross energy
 of days - Calculate AEP by subtracting out the long-term avaiability
 loss (curtailment loss is left in as part of AEP)
 
-.. code:: ipython2
+.. code:: python
 
     # Run Monte-Carlo based OA
     sim_results=pa.run_AEP_monte_carlo(num_sim)
@@ -686,7 +686,7 @@ uncertainty value, namely through capturing the uncertainty in the slope
 and intercept values and the number of years in the windiness
 correction.
 
-.. code:: ipython2
+.. code:: python
 
     # Plot a distribution of APE values from the Monte-Carlo OA method
     
@@ -727,7 +727,7 @@ completed. Note that for transparency, debugging, and analysis purposes,
 we’ve also included in the tracker data frame the number of data points
 used in the regression.
 
-.. code:: ipython2
+.. code:: python
 
     # Produce histograms of the various MC-parameters
     mc_reg = pd.DataFrame(data = {'slope': pa._mc_slope,
@@ -756,7 +756,7 @@ observe the following:
    num_years_windiness, loss_threshold, and reanalysis_product, as
    expected
 
-.. code:: ipython2
+.. code:: python
 
     plt.figure(figsize=(15,15))
     for s in np.arange(mc_reg.shape[1]):
@@ -780,7 +780,7 @@ we assure we aren’t sampling unrealisic combinations.
 
 The plot below shows that the values are being sampled appropriately
 
-.. code:: ipython2
+.. code:: python
 
     # Produce scatter plots of slope and intercept values, and overlay the resulting line of best fits over the actual wind speed 
     # and gross energy data points. Here we focus on the ERA-I data
@@ -800,7 +800,7 @@ We can look further at the influence of certain Monte Carlo parameters
 on the AEP result. For example, let’s see what effect the choice of
 reanalysis product has on the result:
 
-.. code:: ipython2
+.. code:: python
 
     # Boxplot of AEP based on choice of reanalysis product
     
@@ -823,7 +823,7 @@ slightly higher estimate.
 We can also look at the effect on the number of years used in the
 windiness correction:
 
-.. code:: ipython2
+.. code:: python
 
     # Boxplot of AEP based on number of years in windiness correction
     

--- a/sphinx/requirements.txt
+++ b/sphinx/requirements.txt
@@ -1,0 +1,4 @@
+# Requirements for the OpenOA documentation
+sphinx==1.5.6
+sphinxcontrib-napoleon==0.6.1
+sphinx_rtd_theme==0.2.4

--- a/sphinx/requirements.txt
+++ b/sphinx/requirements.txt
@@ -1,12 +1,15 @@
 # Requirements for the OpenOA documentation
 eia-python==1.22
-numpy==1.16.1
-geopandas==0.5.0
-pandas==0.24.2
+geopandas==0.4.0
+numpy==1.15.4
+pandas==0.23.4
 pygam==0.8.0
-scipy==1.2.1
+scipy==1.1.0
 sphinx==1.5.6
 sphinxcontrib-napoleon==0.6.1
 sphinx_rtd_theme==0.2.4
 statsmodels==0.9.0
-tqdm==4.31.1
+tqdm==4.28.1
+
+# not included in main requirements
+m2r==0.2.1

--- a/sphinx/requirements.txt
+++ b/sphinx/requirements.txt
@@ -1,4 +1,12 @@
 # Requirements for the OpenOA documentation
+eia-python==1.22
+numpy==1.16.1
+geopandas==0.5.0
+pandas==0.24.2
+pygam==0.8.0
+scipy==1.2.1
 sphinx==1.5.6
 sphinxcontrib-napoleon==0.6.1
 sphinx_rtd_theme==0.2.4
+statsmodels==0.9.0
+tqdm==4.31.1

--- a/sphinx/requirements.txt
+++ b/sphinx/requirements.txt
@@ -5,11 +5,11 @@ numpy==1.15.4
 pandas==0.23.4
 pygam==0.8.0
 scipy==1.1.0
-sphinx==1.5.6
-sphinxcontrib-napoleon==0.6.1
-sphinx_rtd_theme==0.2.4
 statsmodels==0.9.0
 tqdm==4.28.1
 
 # not included in main requirements
 m2r==0.2.1
+sphinx==2.0.0
+sphinxcontrib-napoleon==0.6.1
+sphinx_rtd_theme==0.2.4


### PR DESCRIPTION
This pull request fixes errors in the Sphinx configuration for readthedocs and closes issue #6.

These are the updates included here:
- Some requirements were missing from the documentaiton-specific requirements file so that is updated
- An extension to convert markdown to rst, `m2r`, has been added to the sphinx configuration file
- An invalid python lexer, `ipython2`, was changed to `python`
- The biggest fix: updating the sphinx version to 2.0.0

Note: these updates get the build to finish successfully, but there are still errors within the documentation. For example, the python lever is not appropriate for all code blocks so the appropriate ones from the [pygments documentation](http://pygments.org/docs/lexers/) should be chosen.