### PR TITLE
Adjust air density calculation to the IEC 61400-12 definition

### DIFF
--- a/operational_analysis/toolkits/met_data_processing.py
+++ b/operational_analysis/toolkits/met_data_processing.py
@@ -45,7 +45,7 @@ def compute_u_v_components(wind_speed, wind_dir):
     return u, v
 
 
-def compute_air_density(df, temp_col, pres_col, humi_col = 'default'):
+def compute_air_density(df, temp_col, pres_col, humi_col = None):
     """
     Calculate air density from the ideal gas law based on the definition provided by IEC 61400-12
     given pressure, temperature and relative humidity.
@@ -63,14 +63,13 @@ def compute_air_density(df, temp_col, pres_col, humi_col = 'default'):
         :obj:`pandas.Series`: Rho, calcualted air density; units of kg/m3
     """
     # Check if humidity column is provided and create default df (0.5) if necessary
-    if humi_col in df:
+    if humi_col in df and humi_col != None:
         rel_humidity = df.loc[:, [humi_col]]
     else:
+        humi_col = 'relative_humidity'
         rel_humidity = pd.DataFrame([0.5]*df[temp_col].shape[0],columns=[humi_col], index=df.index)
-        df['default'] = [0.5]*df[temp_col].shape[0]
     # Send exception if any negative data found
-    if (df.loc[df[temp_col] < 0].shape[0] > 0) | (df.loc[df[pres_col] < 0].shape[0] > 0 
-       | (rel_humidity.loc[rel_humidity[humi_col] < 0].shape[0] > 0)):
+    if (df[temp_col] < 0).any() | (df[pres_col] < 0).any() | (rel_humidity[humi_col] < 0).any():
         raise Exception('Some of your temperature, pressure or humidity data is negative. Check your data.')
 
     R_const = 287.05  # Gas constant for dry air, units of J/kg/K

--- a/operational_analysis/toolkits/met_data_processing.py
+++ b/operational_analysis/toolkits/met_data_processing.py
@@ -50,7 +50,7 @@ def compute_air_density(df, temp_col, pres_col, humi_col = 'default'):
     Calculate air density from the ideal gas law based on the definition provided by IEC 61400-12
     given pressure, temperature and relative humidity.
     This function assumes temperature and pressure are reported in standard units of measurement
-    (i.e. Kelvin for temperature, Pascal for pressure, humidity has no dimension)
+    (i.e. Kelvin for temperature, Pascal for pressure, humidity has no dimension).
     Humidity values are optional. According to the IEC a humiditiy of 50% (0.5) is set as default value. 
 
     Args:

--- a/test/test_met_data_processing_toolkit.py
+++ b/test/test_met_data_processing_toolkit.py
@@ -37,7 +37,7 @@ class SimpleMetProcessing(unittest.TestCase):
         df = pd.DataFrame(data={'temp': np.arange(280, 300, 5), 'pres': np.arange(90000, 110000, 5000)})
 
         rho = mt.compute_air_density(df, 'temp', 'pres')  # Test result
-        rho_ans = np.array([1.11973, 1.16121, 1.20125, 1.23993])  # Expected result
+        rho_ans = np.array([1.11744, 1.1581 , 1.19706, 1.23427])  # Expected result
 
         nptest.assert_array_almost_equal(rho, rho_ans, decimal=5)
 


### PR DESCRIPTION
Solves the issues stated in #10. The calculation of air density is now equal to the IEC 61400-12 definition.  The unit test fails till the expected results are modified as well. 

- Air density calculations considers now humidity and use a default value of 0.5 in case of missing values. 
- The gas constant for dry air is changed to the IEC standard of 287.05 instead of 287.058. The IEC definition is less precise in this point but the definition should still be streamlined with the standard.
- Modified the expected test results accordingly. Due to less the precise gas constant for dry air and 50% humidity.
