### PR TITLE
Fix divide by zero warning in L5P power curve

### DIFF
--- a/operational_analysis/toolkits/power_curve/parametric_forms.py
+++ b/operational_analysis/toolkits/power_curve/parametric_forms.py
@@ -32,7 +32,7 @@ def logistic5param(x, a, b, c, d, g):
         Function[pandas.Series[real]] -> pandas.Series[real]
 
     """
-    return np.where(x!=0, d + (a - d) / (1 + (x / c) ** b) ** g, 0)
+    return np.where(x!=0.0, d + (a - d) / (1 + (x / c) ** b) ** g, d)
 
 
 def logistic5param_capped(x, a, b, c, d, g, lower, upper):

--- a/operational_analysis/toolkits/power_curve/parametric_forms.py
+++ b/operational_analysis/toolkits/power_curve/parametric_forms.py
@@ -35,10 +35,10 @@ def logistic5param(x, a, b, c, d, g):
 
     # In the case where b<0, x==0, there is a divide by zero error. The answer should be "d" when x==0 and b<0.
     if b < 0:
-        res = np.ones_like(x)*d # Initialize result, default value is d
+        res = np.ones_like(x, dtype=np.float)*d # Initialize result, default value is d
         dom = (x!=0.0) # Only nonzero elements in domain
     else:
-        res = np.ones_like(x) # Initialize result, this default value is arbitrary
+        res = np.ones_like(x, dtype=np.float) # Initialize result, this default value is arbitrary
         dom = slice(None) # All elements in domain
 
     # Apply power curve definition to point within domain

--- a/operational_analysis/toolkits/power_curve/parametric_forms.py
+++ b/operational_analysis/toolkits/power_curve/parametric_forms.py
@@ -32,7 +32,7 @@ def logistic5param(x, a, b, c, d, g):
         Function[pandas.Series[real]] -> pandas.Series[real]
 
     """
-    return d + (a - d) / (1 + (x / c) ** b) ** g
+    return np.where(x!=0, d + (a - d) / (1 + (x / c) ** b) ** g, 0)
 
 
 def logistic5param_capped(x, a, b, c, d, g, lower, upper):

--- a/operational_analysis/toolkits/power_curve/parametric_forms.py
+++ b/operational_analysis/toolkits/power_curve/parametric_forms.py
@@ -33,12 +33,12 @@ def logistic5param(x, a, b, c, d, g):
 
     """
 
+    res = np.ones_like(x, dtype=np.float)
     # In the case where b<0, x==0, there is a divide by zero error. The answer should be "d" when x==0 and b<0.
     if b < 0:
-        res = np.ones_like(x, dtype=np.float)*d # Initialize result, default value is d
+        res *= d # Initialize result, default value is d
         dom = (x!=0.0) # Only nonzero elements in domain
     else:
-        res = np.ones_like(x, dtype=np.float) # Initialize result, this default value is arbitrary
         dom = slice(None) # All elements in domain
 
     # Apply power curve definition to point within domain

--- a/operational_analysis/toolkits/power_curve/parametric_forms.py
+++ b/operational_analysis/toolkits/power_curve/parametric_forms.py
@@ -32,7 +32,16 @@ def logistic5param(x, a, b, c, d, g):
         Function[pandas.Series[real]] -> pandas.Series[real]
 
     """
-    return np.where(x!=0.0, d + (a - d) / (1 + (x / c) ** b) ** g, d)
+
+    # In the case where b<0, x==0, there is a divide by zero error. The answer should be "d" when x==0 and b<0.
+    if b < 0:
+        res = np.ones_like(x)*d
+        idx = (x!=0.0)
+        res[idx] =  d + (a - d) / (1 + (x[idx] / c) ** b) ** g
+    else:
+        res = d + (a - d) / (1 + (x / c) ** b) ** g
+
+    return res
 
 
 def logistic5param_capped(x, a, b, c, d, g, lower, upper):

--- a/operational_analysis/toolkits/power_curve/parametric_forms.py
+++ b/operational_analysis/toolkits/power_curve/parametric_forms.py
@@ -35,11 +35,15 @@ def logistic5param(x, a, b, c, d, g):
 
     # In the case where b<0, x==0, there is a divide by zero error. The answer should be "d" when x==0 and b<0.
     if b < 0:
-        res = np.ones_like(x)*d
-        idx = (x!=0.0)
-        res[idx] =  d + (a - d) / (1 + (x[idx] / c) ** b) ** g
+        res = np.ones_like(x)*d # Initialize result, default value is d
+        dom = (x!=0.0) # Only nonzero elements in domain
     else:
-        res = d + (a - d) / (1 + (x / c) ** b) ** g
+        res = np.ones_like(x) # Initialize result, this default value is arbitrary
+        dom = slice(None) # All elements in domain
+
+    # Apply power curve definition to point within domain
+    l5p = lambda xx: d + (a - d) / (1 + (xx / c) ** b) ** g
+    res[dom] =  l5p(x[dom])
 
     return res
 

--- a/test/test_power_curve_toolkit.py
+++ b/test/test_power_curve_toolkit.py
@@ -58,7 +58,18 @@ class TestParametricForms(unittest.TestCase):
         y_pred = logistic5param(np.array([1., 2., 3.]), *[1300., -7., 11., 2., 0.5])
         y = np.array([2.29403585, 5.32662505, 15.74992462])
         nptest.assert_allclose(y, y_pred, err_msg="Power curve did not properly fit.")
-        pass
+
+        y_pred = logistic5param(np.array([1, 2, 3]), *[1300., -7., 11., 2., 0.5])
+        y = np.array([2.29403585, 5.32662505, 15.74992462])
+        nptest.assert_allclose(y, y_pred, err_msg="Power curve did not handle integer inputs properly.")
+
+        y_pred = logistic5param(np.array([0.01, 0.0]), 1300, 7, 11, 2, 0.5)
+        y = np.array([ 1300.0 , 1300.0 ])
+        nptest.assert_allclose(y, y_pred, err_msg="Power curve did not handle zero properly (b>0).")
+
+        y_pred = logistic5param(np.array([0.01, 0.0]), 1300, -7, 11, 2, 0.5)
+        y = np.array([ 2.0 , 2.0 ])
+        nptest.assert_allclose(y, y_pred, err_msg="Power curve did not handle zero properly (b<0).")
 
     def test_logistic5parameter_capped(self):
         # Numpy array + Lower Bound


### PR DESCRIPTION
Resolves issue #21 by wrapping power curve in an "np.where" clause to catch the case where input power is zero. It returns parameter "d" in the case where x is zero.

Here is the new behavior at x=0 using parameters from the test case:
```
>> from operational_analysis.toolkits.power_curve.parametric_forms import *
>> logistic5param(np.array([1,0.5,0.25,0.1, 0.0]), 1300, -7, 11, 2, 0.5)

array([2.29403585, 2.02598934, 2.00229716, 2.00009298, 2.        ])
```