### PR TITLE
Make TIE and electrical losses backward compatible + ENGIE tests

### DIFF
--- a/examples/QC_analysis/project_engie_scada.py
+++ b/examples/QC_analysis/project_engie_scada.py
@@ -89,7 +89,7 @@ class Project_Engie(PlantData):
                      "ID"       : "id",
                      "Power_W"              : "wtur_W_avg",
                      "wmet_wdspd_avg"    : "wmet_wdspd_avg", 
-                     "wmet_wDir_avg"    : "wmet_HorWd_Dir"
+                     "wmet_wDir_avg"    : "wmet_wDir_avg"
                      }
 
         self._scada.df.rename(scada_map, axis="columns", inplace=True)

--- a/examples/QC_analysis/project_engie_scada.py
+++ b/examples/QC_analysis/project_engie_scada.py
@@ -67,14 +67,14 @@ class Project_Engie(PlantData):
         #Handle extrema values
         self._scada.df = self._scada.df[(self._scada.df["wmet_wdspd_avg"]>=0.0) & (self._scada.df["wmet_wdspd_avg"]<=40.0)]
         self._scada.df = self._scada.df[(self._scada.df["wtur_W_avg"]>=-1000.0) & (self._scada.df["wtur_W_avg"]<=2200.0)]
-        self._scada.df = self._scada.df[(self._scada.df["wmet_wDir_avg"]>=0.0) & (self._scada.df["wmet_wDir_avg"]<=360.0)]            
+        self._scada.df = self._scada.df[(self._scada.df["wmet_wdir_avg"]>=0.0) & (self._scada.df["wmet_wdir_avg"]<=360.0)]            
 
         logger.info("Flagging unresponsive sensors")
         #Flag repeated values from frozen sensors
         temp_flag = filters.unresponsive_flag(self._scada.df["wmet_wdspd_avg"], 3)
         self._scada.df.loc[temp_flag, 'wmet_wdspd_avg'] = np.nan
-        temp_flag = filters.unresponsive_flag(self._scada.df["wmet_wDir_avg"], 3)
-        self._scada.df.loc[temp_flag, 'wmet_wDir_avg'] = np.nan
+        temp_flag = filters.unresponsive_flag(self._scada.df["wmet_wdir_avg"], 3)
+        self._scada.df.loc[temp_flag, 'wmet_wdir_avg'] = np.nan
         
         # Put power in watts; note although the field name suggests 'watts', it was really reporting in kw
         self._scada.df["Power_W"] = self._scada.df["wtur_W_avg"] * 1000
@@ -89,7 +89,7 @@ class Project_Engie(PlantData):
                      "ID"       : "id",
                      "Power_W"              : "wtur_W_avg",
                      "wmet_wdspd_avg"    : "wmet_wdspd_avg", 
-                     "wmet_wDir_avg"    : "wmet_wDir_avg"
+                     "wmet_wdir_avg"    : "wmet_wdir_avg"
                      }
 
         self._scada.df.rename(scada_map, axis="columns", inplace=True)

--- a/examples/project_ENGIE.py
+++ b/examples/project_ENGIE.py
@@ -124,7 +124,7 @@ class Project_Engie(PlantData):
                     "time"                 : "time",
                     "Wind_turbine_name"    : "id",
                     "Power_W"              : "wtur_W_avg",
-                    "Ws_avg"               : "wmet_HorWdSpd_avg", 
+                    "Ws_avg"               : "wmet_wdspd_avg", 
                     "Wa_avg"               : "wmet_HorWdDir_avg",
                     "Va_avg"               : "wmet_VaneDir_avg", 
                     "Ya_avg"               : "wyaw_YwAng_avg",

--- a/examples/project_ENGIE.py
+++ b/examples/project_ENGIE.py
@@ -125,11 +125,11 @@ class Project_Engie(PlantData):
                     "Wind_turbine_name"    : "id",
                     "Power_W"              : "wtur_W_avg",
                     "Ws_avg"               : "wmet_wdspd_avg", 
-                    "Wa_avg"               : "wmet_HorWdDir_avg",
-                    "Va_avg"               : "wmet_VaneDir_avg", 
-                    "Ya_avg"               : "wyaw_YwAng_avg",
-                    "Ot_avg"               : "wmet_EnvTmp_avg",
-                    "Ba_avg"               : "wrot_BlPthAngVal1_avg",
+                    "Wa_avg"               : "wmet_wDir_avg",
+                    "Va_avg"               : "wmet_vanedir_avg", 
+                    "Ya_avg"               : "wyaw_ywang_avg",
+                    "Ot_avg"               : "wmet_envtmp_avg",
+                    "Ba_avg"               : "wrot_blpthangval1_avg",
                     "energy_kwh"           : "energy_kwh"
                     }
 

--- a/examples/project_ENGIE.py
+++ b/examples/project_ENGIE.py
@@ -125,7 +125,7 @@ class Project_Engie(PlantData):
                     "Wind_turbine_name"    : "id",
                     "Power_W"              : "wtur_W_avg",
                     "Ws_avg"               : "wmet_wdspd_avg", 
-                    "Wa_avg"               : "wmet_wDir_avg",
+                    "Wa_avg"               : "wmet_wdir_avg",
                     "Va_avg"               : "wmet_vanedir_avg", 
                     "Ya_avg"               : "wyaw_ywang_avg",
                     "Ot_avg"               : "wmet_envtmp_avg",

--- a/examples/turbine_analysis/engie_project.py
+++ b/examples/turbine_analysis/engie_project.py
@@ -44,7 +44,7 @@ class TurbineEngieOpenData(PlantData):
                  self.scada.df.append(pd.read_json(url,orient='columns'), ignore_index=True)
         self.scada.rename_columns({"time": "date_time",
                                    "wtur_W_avg": "p_avg",
-                                   "wmet_wDir_avg": "wa_avg",
+                                   "wmet_wdir_avg": "wa_avg",
                                    "wmet_wdspd_avg": "ws_avg"})
         self.scada.df.set_index('time', inplace=True, drop=False)
         self.scada.df.drop(['date_time', 'p_avg', 'wa_avg', 'ws_avg'], axis=1, inplace=True)

--- a/operational_analysis/methods/electrical_losses.py
+++ b/operational_analysis/methods/electrical_losses.py
@@ -80,13 +80,11 @@ class ElectricalLosses(object):
             (None)
         """
         # Define uncertainties and check types
-        if self.UQ == False:
-            if type(uncertainty_correction_thresh) != float:
-                logger.info("uncertainty_correction_thresh needs to be a float if UQ is False!")
+        expected_type = float if self.UQ == False else tuple
+        assert type(uncertainty_correction_thresh) == expected_type,  f"uncertainty_correction_thresh must be {expected_type} for UQ={self.UQ}"
+
         self.uncertainty_correction_thresh = np.array(uncertainty_correction_thresh, dtype=np.float64)  
         if self.UQ == True:
-            if type(uncertainty_correction_thresh) != tuple:
-                logger.info("uncertainty_correction_thresh needs to be a tuple if UQ is True!")
             self.uncertainty_meter = uncertainty_meter
             self.uncertainty_scada = uncertainty_scada
         

--- a/operational_analysis/methods/electrical_losses.py
+++ b/operational_analysis/methods/electrical_losses.py
@@ -37,29 +37,20 @@ class ElectricalLosses(object):
     """ 
 
     @logged_method_call
-    def __init__(self, plant, UQ = False, num_sim = 20000, uncertainty_meter=0.005, uncertainty_scada=0.005,
-                 uncertainty_correction_thresh=(0.9,0.995)):
+    def __init__(self, plant, UQ = False, num_sim = 20000):
         """
         Initialize electrical losses class with input parameters
         Args:
          plant(:obj:`PlantData object`): PlantData object from which EYAGapAnalysis should draw data.
          num_sim:(:obj:`int`): number of Monte Carlo simulations
-         UQ:(:obj:`bool`): choice whether to perform ('Y') or not ('N') uncertainty quantification
-         uncertainty_meter(:obj:`float`): uncertainty imposed to revenue meter data (for UQ = True case)
-         uncertainty_scada(:obj:`float`): uncertainty imposed to scada data (for UQ = True case)
-         uncertainty_correction_threshold(:obj:`tuple`): The interval of data availability thresholds (fractions) 
-                                                         under which months should be eliminated (for UQ = True case)                                       
+         UQ:(:obj:`bool`): choice whether to perform ('Y') or not ('N') uncertainty quantification                                      
         """
         logger.info("Initializing Electrical Losses Object")
         
         # Check that selected UQ is allowed
         if UQ == True:
             logger.info("Note: uncertainty quantification will be performed in the calculation")
-            self.num_sim = num_sim
-            # Define relevant uncertainties, to be applied in Monte Carlo sampling
-            self.uncertainty_meter = uncertainty_meter
-            self.uncertainty_scada = uncertainty_scada
-            self.uncertainty_correction_thresh = np.array(uncertainty_correction_thresh, dtype=np.float64)  
+            self.num_sim = num_sim 
         elif UQ == False:
             logger.info("Note: uncertainty quantification will NOT be performed in the calculation")
             self.num_sim = 1
@@ -73,17 +64,27 @@ class ElectricalLosses(object):
         self._hours_per_day= 24 # Hours per day converter
     
     @logged_method_call
-    def run(self):
+    def run(self, uncertainty_meter=0.005, uncertainty_scada=0.005,
+                 uncertainty_correction_thresh=(0.9,0.995)):
         """
         Run the electrical loss calculation in order by calling this function.
         
         Args:
-            (None)
+         uncertainty_meter(:obj:`float`): uncertainty imposed to revenue meter data (for UQ = True case)
+         uncertainty_scada(:obj:`float`): uncertainty imposed to scada data (for UQ = True case)
+         uncertainty_correction_threshold(:obj:`tuple`): The interval of data availability thresholds (fractions) 
+                                                         under which months should be eliminated (for UQ = True case) 
             
         Returns:
             (None)
         """
         
+        if self.UQ == True:
+            # Define uncertainties
+            self.uncertainty_meter = uncertainty_meter
+            self.uncertainty_scada = uncertainty_scada
+            self.uncertainty_correction_thresh = np.array(uncertainty_correction_thresh, dtype=np.float64)  
+               
         # Process SCADA data to daily sums
         self.process_scada()
         

--- a/operational_analysis/methods/electrical_losses.py
+++ b/operational_analysis/methods/electrical_losses.py
@@ -65,7 +65,7 @@ class ElectricalLosses(object):
     
     @logged_method_call
     def run(self, uncertainty_meter=0.005, uncertainty_scada=0.005,
-                 uncertainty_correction_thresh=(0.9,0.995)):
+                 uncertainty_correction_thresh=0.95):
         """
         Run the electrical loss calculation in order by calling this function.
         

--- a/operational_analysis/methods/electrical_losses.py
+++ b/operational_analysis/methods/electrical_losses.py
@@ -43,7 +43,7 @@ class ElectricalLosses(object):
         Args:
          plant(:obj:`PlantData object`): PlantData object from which EYAGapAnalysis should draw data.
          num_sim:(:obj:`int`): number of Monte Carlo simulations
-         UQ:(:obj:`bool`): choice whether to perform ('Y') or not ('N') uncertainty quantification                                      
+         UQ:(:obj:`bool`): choice whether to perform (True) or not (False) uncertainty quantification                                      
         """
         logger.info("Initializing Electrical Losses Object")
         
@@ -72,9 +72,10 @@ class ElectricalLosses(object):
         Args:
          uncertainty_meter(:obj:`float`): uncertainty imposed to revenue meter data (for UQ = True case)
          uncertainty_scada(:obj:`float`): uncertainty imposed to scada data (for UQ = True case)
-         uncertainty_correction_threshold(:obj:`tuple`): The interval of data availability thresholds (fractions) 
-                                                         under which months should be eliminated (for UQ = True case) 
-            
+         uncertainty_correction_threshold(:obj:`tuple`): Data availability thresholds (fractions) 
+                                                         under which months should be eliminated. 
+                                                         This should be a tuple in the UQ = True case, 
+                                                         a single value when UQ = False.
         Returns:
             (None)
         """
@@ -125,7 +126,7 @@ class ElectricalLosses(object):
             inputs = {
                 "meter_data_fraction": 1,
                 "scada_data_fraction": 1,
-                "correction_threshold": 0.90,
+                "correction_threshold": self.uncertainty_correction_threshold,
             }
             self._inputs = pd.DataFrame(inputs,index=[0])
 

--- a/operational_analysis/methods/electrical_losses.py
+++ b/operational_analysis/methods/electrical_losses.py
@@ -79,13 +79,17 @@ class ElectricalLosses(object):
         Returns:
             (None)
         """
-        # Define uncertainties
+        # Define uncertainties and check types
+        if self.UQ == False:
+            if type(uncertainty_correction_thresh) != float:
+                logger.info("uncertainty_correction_thresh needs to be a float if UQ is False!")
         self.uncertainty_correction_thresh = np.array(uncertainty_correction_thresh, dtype=np.float64)  
         if self.UQ == True:
+            if type(uncertainty_correction_thresh) != tuple:
+                logger.info("uncertainty_correction_thresh needs to be a tuple if UQ is True!")
             self.uncertainty_meter = uncertainty_meter
             self.uncertainty_scada = uncertainty_scada
         
-               
         # Process SCADA data to daily sums
         self.process_scada()
         

--- a/operational_analysis/methods/electrical_losses.py
+++ b/operational_analysis/methods/electrical_losses.py
@@ -79,12 +79,12 @@ class ElectricalLosses(object):
         Returns:
             (None)
         """
-        
+        # Define uncertainties
+        self.uncertainty_correction_thresh = np.array(uncertainty_correction_thresh, dtype=np.float64)  
         if self.UQ == True:
-            # Define uncertainties
             self.uncertainty_meter = uncertainty_meter
             self.uncertainty_scada = uncertainty_scada
-            self.uncertainty_correction_thresh = np.array(uncertainty_correction_thresh, dtype=np.float64)  
+        
                
         # Process SCADA data to daily sums
         self.process_scada()

--- a/operational_analysis/methods/electrical_losses.py
+++ b/operational_analysis/methods/electrical_losses.py
@@ -72,7 +72,7 @@ class ElectricalLosses(object):
         Args:
          uncertainty_meter(:obj:`float`): uncertainty imposed to revenue meter data (for UQ = True case)
          uncertainty_scada(:obj:`float`): uncertainty imposed to scada data (for UQ = True case)
-         uncertainty_correction_threshold(:obj:`tuple`): Data availability thresholds (fractions) 
+         uncertainty_correction_thresh(:obj:`tuple`): Data availability thresholds (fractions) 
                                                          under which months should be eliminated. 
                                                          This should be a tuple in the UQ = True case, 
                                                          a single value when UQ = False.
@@ -126,7 +126,7 @@ class ElectricalLosses(object):
             inputs = {
                 "meter_data_fraction": 1,
                 "scada_data_fraction": 1,
-                "correction_threshold": self.uncertainty_correction_threshold,
+                "correction_threshold": self.uncertainty_correction_thresh,
             }
             self._inputs = pd.DataFrame(inputs,index=[0])
 

--- a/operational_analysis/methods/turbine_long_term_gross_energy.py
+++ b/operational_analysis/methods/turbine_long_term_gross_energy.py
@@ -126,6 +126,21 @@ class TurbineLongTermGrossEnergy(object):
         
         self._reanal = reanal_subset # Reanalysis data to consider in fitting
         
+        # Check uncertainty types
+        if self.UQ == False:
+            if type(wind_bin_thresh) != float:
+                logger.info("wind_bin_thresh needs to be a float if UQ is False!")
+            if type(max_power_filter) != float:
+                logger.info("max_power_filter needs to be a float if UQ is False!")
+            if type(correction_threshold) != float:
+                logger.info("correction_threshold needs to be a float if UQ is False!")
+        if self.UQ == True:
+            if type(wind_bin_thresh) != tuple:
+                logger.info("wind_bin_thresh needs to be a tuple if UQ is True!")
+            if type(max_power_filter) != tuple:
+                logger.info("max_power_filter needs to be a tuple if UQ is True!")
+            if type(correction_threshold) != tuple:
+                logger.info("correction_threshold needs to be a tuple if UQ is True!")        
         # Define relevant uncertainties, to be applied in Monte Carlo sampling
         self.uncertainty_wind_bin_thresh = np.array(wind_bin_thresh, dtype=np.float64)
         self.uncertainty_max_power_filter = np.array(max_power_filter, dtype=np.float64)

--- a/operational_analysis/methods/turbine_long_term_gross_energy.py
+++ b/operational_analysis/methods/turbine_long_term_gross_energy.py
@@ -127,20 +127,11 @@ class TurbineLongTermGrossEnergy(object):
         self._reanal = reanal_subset # Reanalysis data to consider in fitting
         
         # Check uncertainty types
-        if self.UQ == False:
-            if type(wind_bin_thresh) != float:
-                logger.info("wind_bin_thresh needs to be a float if UQ is False!")
-            if type(max_power_filter) != float:
-                logger.info("max_power_filter needs to be a float if UQ is False!")
-            if type(correction_threshold) != float:
-                logger.info("correction_threshold needs to be a float if UQ is False!")
-        if self.UQ == True:
-            if type(wind_bin_thresh) != tuple:
-                logger.info("wind_bin_thresh needs to be a tuple if UQ is True!")
-            if type(max_power_filter) != tuple:
-                logger.info("max_power_filter needs to be a tuple if UQ is True!")
-            if type(correction_threshold) != tuple:
-                logger.info("correction_threshold needs to be a tuple if UQ is True!")        
+        vars = [wind_bin_thresh, max_power_filter, correction_threshold]
+        expected_type = float if self.UQ == False else tuple
+        for var in vars:
+            assert type(var) == expected_type,  f"wind_bin_thresh, max_power_filter, correction_threshold must all be {expected_type} for UQ={self.UQ}"
+        
         # Define relevant uncertainties, to be applied in Monte Carlo sampling
         self.uncertainty_wind_bin_thresh = np.array(wind_bin_thresh, dtype=np.float64)
         self.uncertainty_max_power_filter = np.array(max_power_filter, dtype=np.float64)

--- a/operational_analysis/methods/turbine_long_term_gross_energy.py
+++ b/operational_analysis/methods/turbine_long_term_gross_energy.py
@@ -73,9 +73,6 @@ class TurbineLongTermGrossEnergy(object):
             self.num_sim = num_sim
             # Define relevant uncertainties, to be applied in Monte Carlo sampling
             self.uncertainty_scada = uncertainty_scada
-            self.uncertainty_wind_bin_thresh = np.array(uncertainty_wind_bin_thresh, dtype=np.float64)
-            self.uncertainty_max_power_filter = np.array(uncertainty_max_power_filter, dtype=np.float64)
-            self.uncertainty_correction_threshold = np.array(uncertainty_correction_threshold, dtype=np.float64)
         elif UQ == False:    
             logger.info("Note: uncertainty quantification will NOT be performed in the calculation")
             self.num_sim = None
@@ -86,6 +83,11 @@ class TurbineLongTermGrossEnergy(object):
         self._plant = plant  # Set plant as attribute of analysis object
         self._turbs = self._plant._scada.df['id'].unique() # Store turbine names
         self._reanal = reanal_subset # Reanalysis data to consider in fitting
+        
+        # Define relevant uncertainties, to be applied in Monte Carlo sampling
+        self.uncertainty_wind_bin_thresh = np.array(uncertainty_wind_bin_thresh, dtype=np.float64)
+        self.uncertainty_max_power_filter = np.array(uncertainty_max_power_filter, dtype=np.float64)
+        self.uncertainty_correction_threshold = np.array(uncertainty_correction_threshold, dtype=np.float64)
         
         # Get start and end of POR days in SCADA
         self._por_start = format(plant._scada.df.index.min(), '%Y-%m-%d')
@@ -192,9 +194,9 @@ class TurbineLongTermGrossEnergy(object):
             inputs = {
                 "reanalysis_product": self._reanal,
                 "scada_data_fraction": 1,
-                "wind_bin_thresh": 2,
-                "max_power_filter": 0.85,
-                "correction_threshold": 0.90,
+                "wind_bin_thresh": self.uncertainty_wind_bin_thresh,
+                "max_power_filter": self.uncertainty_max_power_filter,
+                "correction_threshold": self.uncertainty_correction_threshold,
             }
             self._plant_gross = np.empty([len(self._reanal),1])
             self.num_sim = len(self._reanal)

--- a/operational_analysis/methods/turbine_long_term_gross_energy.py
+++ b/operational_analysis/methods/turbine_long_term_gross_energy.py
@@ -106,10 +106,13 @@ class TurbineLongTermGrossEnergy(object):
          reanal_subset(:obj:`list`): Which reanalysis products to use for long-term correction
          uncertainty_scada(:obj:`float`): uncertainty imposed to scada data (used in UQ = True case only)
          max_power_filter(:obj:`tuple`): Maximum power threshold (fraction) to which the bin filter 
-                                         should be applied (default 0.85)
-         wind_bin_thresh(:obj:`tuple`): The filter threshold for each bin (default is 2 m/s)
+                                         should be applied (default 0.85). This should be a tuple in the UQ = True case, 
+                                         a single value when UQ = False.
+         wind_bin_thresh(:obj:`tuple`): The filter threshold for each bin (default is 2 m/s). 
+                                         This should be a tuple in the UQ = True case, a single value when UQ = False.
          correction_threshold(:obj:`tuple`): The threshold (fraction) above which daily scada energy data
-                                                should be corrected (default is 0.90)
+                                             hould be corrected (default is 0.90). 
+                                             This should be a tuple in the UQ = True case, a single value when UQ = False.
          enable_plotting(:obj:`boolean`): Indicate whether to output plots
          plot_dir(:obj:`string`): Location to save figures
             

--- a/test/int_electrical_losses.py
+++ b/test/int_electrical_losses.py
@@ -45,7 +45,7 @@ class TestElectricalLossesUQ(unittest.TestCase):
         # Create electrical loss method object and run
         # WITH UQ
         self.analysis_uq = ElectricalLosses(self.project, UQ = True, num_sim = 3000)
-        self.analysis_uq.run()
+        self.analysis_uq.run(uncertainty_correction_thresh = (0.9, 0.995))
 
     def test_electrical_losses_results(self):
         

--- a/test/int_electrical_losses.py
+++ b/test/int_electrical_losses.py
@@ -4,48 +4,25 @@ import numpy as np
 import numpy.testing as npt
 
 from operational_analysis.methods.electrical_losses import ElectricalLosses
-from examples.turbine_analysis.turbine_project import TurbineExampleProject
+from examples.project_ENGIE import Project_Engie
 
 class TestElectricalLosses(unittest.TestCase):
 
     def setUp(self):
         np.random.seed(42)
-        
-        # Set up data to use for testing (TurbineExampleProject)
-        self.project = TurbineExampleProject('./examples/turbine_analysis/data')
+        # Set up data to use for testing (ENGIE data)
+        self.project = Project_Engie('./examples/data/la_haute_borne')
         self.project.prepare()
-        
-        # SCADA DATA
-        # Synthesize two turbines from example turbine data and create new scada dataframe
-        # First turbine is from the real data
-        scada_1_df = self.project._scada.df[['id', 'energy_kwh']]
-        # Create second turbine
-        scada_temp = self.project._scada.df
-        scada_temp['id'] = 'T1'
-        # Normal distribution centered on 1 -> second turbine has same average energy production as turbine 1
-        scada_temp['energy_kwh'] = scada_1_df['energy_kwh'] * np.random.randint(80, 120, scada_1_df.shape[0])/100
-        scada_2_df = scada_temp[['id', 'energy_kwh']]
-        # Put two turbines together
-        self.project._scada.df = scada_1_df.append(scada_2_df)
-        self.project._num_turbines = 2
-        
-        # METER DATA
-        # Synthesize metered data from scada dataframe
-        meter_df = scada_1_df['energy_kwh'].to_frame()
-        # Meter data as a fraction of twice (because there are 2 turbines) the scada data
-        meter_df['energy_kwh'] = meter_df['energy_kwh'] * 2 * np.random.randint(98, 100, scada_1_df.shape[0])/100
-        self.project._meter.df = meter_df
-        self.project._meter_freq = '10T'
 
         # Create electrical loss method object and run
         # NO UQ case
         self.analysis = ElectricalLosses(self.project, UQ = False)
-        self.analysis.run()
+        self.analysis.run(uncertainty_correction_thresh = 0.95)
 
     def test_electrical_losses_results(self):
         
         # Check that the computed electrical loss means and their std are as expected
-        expected_losses = 0.0126
+        expected_losses = 0.02
         expected_losses_std = 0
         actual_compiled_data = self.analysis._electrical_losses.mean()
         actual_compiled_data_std = self.analysis._electrical_losses.std()
@@ -61,32 +38,9 @@ class TestElectricalLossesUQ(unittest.TestCase):
 
     def setUp(self):
         np.random.seed(42)
-        
-        # Set up data to use for testing (TurbineExampleProject)
-        self.project = TurbineExampleProject('./examples/turbine_analysis/data')
+        # Set up data to use for testing (ENGIE data)
+        self.project = Project_Engie('./examples/data/la_haute_borne')
         self.project.prepare()
-        
-        # SCADA DATA
-        # Synthesize two turbines from example turbine data and create new scada dataframe
-        # First turbine is from the real data
-        scada_1_df = self.project._scada.df[['id', 'energy_kwh']]
-        # Create second turbine
-        scada_temp = self.project._scada.df
-        scada_temp['id'] = 'T1'
-        # Normal distribution centered on 1 -> second turbine has same average energy production as turbine 1
-        scada_temp['energy_kwh'] = scada_1_df['energy_kwh'] * np.random.randint(80, 120, scada_1_df.shape[0])/100
-        scada_2_df = scada_temp[['id', 'energy_kwh']]
-        # Put two turbines together
-        self.project._scada.df = scada_1_df.append(scada_2_df)
-        self.project._num_turbines = 2
-        
-        # METER DATA
-        # Synthesize metered data from scada dataframe
-        meter_df = scada_1_df['energy_kwh'].to_frame()
-        # Meter data as a fraction of twice (because there are 2 turbines) the scada data
-        meter_df['energy_kwh'] = meter_df['energy_kwh'] * 2 * np.random.randint(98, 100, scada_1_df.shape[0])/100
-        self.project._meter.df = meter_df
-        self.project._meter_freq = '10T'
 
         # Create electrical loss method object and run
         # WITH UQ
@@ -96,8 +50,8 @@ class TestElectricalLossesUQ(unittest.TestCase):
     def test_electrical_losses_results(self):
         
         # Check that the computed electrical loss means and their std are as expected
-        expected_losses_uq = 0.0126
-        expected_losses_uq_std = 0.007
+        expected_losses_uq = 0.02
+        expected_losses_uq_std = 0.0069
         actual_compiled_data_uq = self.analysis_uq._electrical_losses.mean()
         actual_compiled_data_uq_std = self.analysis_uq._electrical_losses.std()
         

--- a/test/int_turbine_long_term_gross_energy.py
+++ b/test/int_turbine_long_term_gross_energy.py
@@ -4,20 +4,19 @@ import numpy as np
 import numpy.testing as npt
 
 from operational_analysis.methods.turbine_long_term_gross_energy import TurbineLongTermGrossEnergy
-from examples.turbine_analysis.turbine_project import TurbineExampleProject
-
+from examples.project_ENGIE import Project_Engie
 
 class TestLongTermGrossEnergy(unittest.TestCase):
 
     def setUp(self):
         np.random.seed(42)
-        # Set up data to use for testing (TurbineExampleProject)
-        self.project = TurbineExampleProject('./examples/turbine_analysis/data')
+        # Set up data to use for testing (ENGIE data)
+        self.project = Project_Engie('./examples/data/la_haute_borne')
         self.project.prepare()
         
         self.analysis = TurbineLongTermGrossEnergy(self.project, UQ = False)
         
-        self.analysis.run(reanal_subset = ['erai', 'merra2', 'ncep2'],
+        self.analysis.run(reanal_subset = ['era5', 'merra2'],
                                                    max_power_filter = 0.85,
                                                    wind_bin_thresh = 1,
                                                    correction_threshold = 0.9,
@@ -27,8 +26,8 @@ class TestLongTermGrossEnergy(unittest.TestCase):
 
         # Test not-UQ case
         res = self.analysis._plant_gross
-        check = np.ones_like(res)*1.35
-        npt.assert_almost_equal(res/1000000, check, decimal=1)
+        check = np.ones_like(res)*13.7
+        npt.assert_almost_equal(res/1e6, check, decimal=1)
         
     def tearDown(self):
         pass
@@ -39,23 +38,23 @@ class TestLongTermGrossEnergyUQ(unittest.TestCase):
     def setUp(self):
         np.random.seed(42)
         # Set up data to use for testing (TurbineExampleProject)
-        self.project = TurbineExampleProject('./examples/turbine_analysis/data')
+        self.project = Project_Engie('./examples/data/la_haute_borne')
         self.project.prepare()
 
         self.analysis_uq = TurbineLongTermGrossEnergy(self.project, UQ = True, num_sim = 100)
-        self.analysis_uq.run(enable_plotting = False, reanal_subset = ['erai', 'merra2', 'ncep2'])
+        self.analysis_uq.run(enable_plotting = False, reanal_subset = ['era5', 'merra2'])
 
     def test_longterm_gross_energy_results(self):
 
         # Test UQ case, mean value
         res_uq = self.analysis_uq._plant_gross.mean()
-        check_uq = 1.35
-        npt.assert_almost_equal(res_uq/1000000, check_uq, decimal=1)
+        check_uq = 13.7
+        npt.assert_almost_equal(res_uq/1e6, check_uq, decimal=1)
 
         # Test UQ case, stdev
         res_std_uq = self.analysis_uq._plant_gross.std()
-        check_std_uq = 0.05
-        npt.assert_almost_equal(res_std_uq/1000000, check_std_uq, decimal=1)
+        check_std_uq = 0.10
+        npt.assert_almost_equal(res_std_uq/1e6, check_std_uq, decimal=1)
         
     def tearDown(self):
         pass

--- a/test/int_turbine_long_term_gross_energy.py
+++ b/test/int_turbine_long_term_gross_energy.py
@@ -18,7 +18,7 @@ class TestLongTermGrossEnergy(unittest.TestCase):
         
         self.analysis.run(reanal_subset = ['era5', 'merra2'],
                                                    max_power_filter = 0.85,
-                                                   wind_bin_thresh = 1,
+                                                   wind_bin_thresh = 1.,
                                                    correction_threshold = 0.9,
                                                    enable_plotting = False)
 

--- a/test/int_turbine_long_term_gross_energy.py
+++ b/test/int_turbine_long_term_gross_energy.py
@@ -15,7 +15,11 @@ class TestLongTermGrossEnergy(unittest.TestCase):
         self.project = TurbineExampleProject('./examples/turbine_analysis/data')
         self.project.prepare()
         
-        self.analysis = TurbineLongTermGrossEnergy(self.project, UQ = False, reanal_subset = ['erai', 'merra2', 'ncep2'])
+        self.analysis = TurbineLongTermGrossEnergy(self.project, UQ = False, 
+                                                   reanal_subset = ['erai', 'merra2', 'ncep2'],
+                                                   uncertainty_max_power_filter = 0.85,
+                                                   uncertainty_wind_bin_thresh = 1,
+                                                   uncertainty_correction_threshold = 0.9)
         self.analysis.run(enable_plotting = False)
 
     def test_longterm_gross_energy_results(self):

--- a/test/int_turbine_long_term_gross_energy.py
+++ b/test/int_turbine_long_term_gross_energy.py
@@ -15,12 +15,13 @@ class TestLongTermGrossEnergy(unittest.TestCase):
         self.project = TurbineExampleProject('./examples/turbine_analysis/data')
         self.project.prepare()
         
-        self.analysis = TurbineLongTermGrossEnergy(self.project, UQ = False, 
-                                                   reanal_subset = ['erai', 'merra2', 'ncep2'],
-                                                   uncertainty_max_power_filter = 0.85,
-                                                   uncertainty_wind_bin_thresh = 1,
-                                                   uncertainty_correction_threshold = 0.9)
-        self.analysis.run(enable_plotting = False)
+        self.analysis = TurbineLongTermGrossEnergy(self.project, UQ = False)
+        
+        self.analysis.run(reanal_subset = ['erai', 'merra2', 'ncep2'],
+                                                   max_power_filter = 0.85,
+                                                   wind_bin_thresh = 1,
+                                                   correction_threshold = 0.9,
+                                                   enable_plotting = False)
 
     def test_longterm_gross_energy_results(self):
 
@@ -41,8 +42,8 @@ class TestLongTermGrossEnergyUQ(unittest.TestCase):
         self.project = TurbineExampleProject('./examples/turbine_analysis/data')
         self.project.prepare()
 
-        self.analysis_uq = TurbineLongTermGrossEnergy(self.project, UQ = True, num_sim = 100, reanal_subset = ['erai', 'merra2', 'ncep2'])
-        self.analysis_uq.run(enable_plotting = False)
+        self.analysis_uq = TurbineLongTermGrossEnergy(self.project, UQ = True, num_sim = 100)
+        self.analysis_uq.run(enable_plotting = False, reanal_subset = ['erai', 'merra2', 'ncep2'])
 
     def test_longterm_gross_energy_results(self):
 


### PR DESCRIPTION
TIE and electrical losses should now be backward compatible, and they should now work with the Examples in PR #71 . 

Also, following @ejsimley 's comments in PR #71 , filter and threshold values (max_power_filter, wind_bin_thresh, correction_threshold) are now not hardcoded anymore in the TIE class.
In the UQ = True case, tuple should be passed for these three parameters (as a range of values is needed in the MC sampling); in the UQ = False case, floats should be passed for these parameters (as no MC sampling is performed on them). I'd need some help on how to make this explicit in the description of the Args, which is used to build documentation. Of course, if you know a better way to express this, please suggest!