### PR TITLE
Exclude plotting functions and module from code coverage report

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,9 @@
+[report]
+exclude_lines =
+    pragma: no cover
+    def .+_plot
+    def plot_.+
+
+[run]
+omit =
+    operational_analysis/toolkits/pandas_plotting.py


### PR DESCRIPTION
This gets us to 69% coverage: https://codecov.io/gh/NREL/OpenOA/branch/feature%2Fexclude-plotting-from-coverage-report