### PR TITLE
Pip packaging

### DIFF
--- a/.github/workflows/tags-to-pypi.yml
+++ b/.github/workflows/tags-to-pypi.yml
@@ -1,4 +1,4 @@
-name: Publish any new version tags (matching 'v*') to PyPi as a new release.
+name: PyPi Publisher
 
 on:
     push:
@@ -7,7 +7,7 @@ on:
 
 jobs:
     build-n-publish:
-        name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+        name: Build and publish Python package to PyPi
         runs-on: ubuntu-18.04
         steps:
             - uses: actions/checkout@master
@@ -15,21 +15,11 @@ jobs:
               uses: actions/setup-python@v1
               with:
                 python-version: 3.7
-            - name: Install pep517
-              run: >-
-                    python -m
-                    pip install
-                    pep517
-                    --user
-            - name: Build a binary wheel and a source tarball
-              run: >-
-                    python -m
-                    pep517.build
-                    --source
-                    --binary
-                    --out-dir dist/
-                    .
-            - name: Publish package to PyPI
+            - name: Build binary tarball
+              run: python setup.py bdist_wheel
+            - name: Build source tarball
+              run: python setup.py sdist --formats=gztar,zip
+            - name: Publish artifacts to PyPI
               uses: pypa/gh-action-pypi-publish@master
               with:
                 password: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/tags-to-pypi.yml
+++ b/.github/workflows/tags-to-pypi.yml
@@ -19,7 +19,7 @@ jobs:
               run: |
                 pip install wheel
                 python setup.py bdist_wheel
-                python setup.py sdist --formats=gztar,zip
+                python setup.py sdist --formats=gztar
             - name: Publish artifacts to PyPI
               uses: pypa/gh-action-pypi-publish@master
               with:

--- a/.github/workflows/tags-to-pypi.yml
+++ b/.github/workflows/tags-to-pypi.yml
@@ -15,9 +15,9 @@ jobs:
               uses: actions/setup-python@v1
               with:
                 python-version: 3.7
-            - name: Build binary tarball
+            - name: Build tarballs
+              run: pip install wheel
               run: python setup.py bdist_wheel
-            - name: Build source tarball
               run: python setup.py sdist --formats=gztar,zip
             - name: Publish artifacts to PyPI
               uses: pypa/gh-action-pypi-publish@master

--- a/.github/workflows/tags-to-pypi.yml
+++ b/.github/workflows/tags-to-pypi.yml
@@ -24,4 +24,4 @@ jobs:
               uses: pypa/gh-action-pypi-publish@master
               with:
                 password: ${{ secrets.PYPI_PASSWORD }}
-                repository_url: https://test.pypi.org/legacy/
+                repository_url: https://pypi.org/legacy/

--- a/.github/workflows/tags-to-pypi.yml
+++ b/.github/workflows/tags-to-pypi.yml
@@ -16,13 +16,13 @@ jobs:
               with:
                 python-version: 3.7
             - name: Install pep517
-                run: >-
+              run: >-
                     python -m
                     pip install
                     pep517
                     --user
             - name: Build a binary wheel and a source tarball
-                run: >-
+              run: >-
                     python -m
                     pep517.build
                     --source
@@ -30,7 +30,7 @@ jobs:
                     --out-dir dist/
                     .
             - name: Publish package to PyPI
-            uses: pypa/gh-action-pypi-publish@master
-            with:
+              uses: pypa/gh-action-pypi-publish@master
+              with:
                 password: ${{ secrets.PYPI_PASSWORD }}
                 repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/tags-to-pypi.yml
+++ b/.github/workflows/tags-to-pypi.yml
@@ -16,9 +16,10 @@ jobs:
               with:
                 python-version: 3.7
             - name: Build tarballs
-              run: pip install wheel
-              run: python setup.py bdist_wheel
-              run: python setup.py sdist --formats=gztar,zip
+              run: |
+                pip install wheel
+                python setup.py bdist_wheel
+                python setup.py sdist --formats=gztar,zip
             - name: Publish artifacts to PyPI
               uses: pypa/gh-action-pypi-publish@master
               with:

--- a/.github/workflows/tags-to-pypi.yml
+++ b/.github/workflows/tags-to-pypi.yml
@@ -1,0 +1,36 @@
+name: Publish any new version tags (matching 'v*') to PyPi as a new release.
+
+on:
+    push:
+        tags:
+            - 'v*'
+
+jobs:
+    build-n-publish:
+        name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+        runs-on: ubuntu-18.04
+        steps:
+            - uses: actions/checkout@master
+            - name: Set up Python 3.7
+              uses: actions/setup-python@v1
+              with:
+                python-version: 3.7
+            - name: Install pep517
+            run: >-
+                python -m
+                pip install
+                pep517
+                --user
+            - name: Build a binary wheel and a source tarball
+            run: >-
+                python -m
+                pep517.build
+                --source
+                --binary
+                --out-dir dist/
+                .
+            - name: Publish package to PyPI
+            uses: pypa/gh-action-pypi-publish@master
+            with:
+                password: ${{ secrets.PYPI_PASSWORD }}
+                repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/tags-to-pypi.yml
+++ b/.github/workflows/tags-to-pypi.yml
@@ -16,19 +16,19 @@ jobs:
               with:
                 python-version: 3.7
             - name: Install pep517
-            run: >-
-                python -m
-                pip install
-                pep517
-                --user
+                run: >-
+                    python -m
+                    pip install
+                    pep517
+                    --user
             - name: Build a binary wheel and a source tarball
-            run: >-
-                python -m
-                pep517.build
-                --source
-                --binary
-                --out-dir dist/
-                .
+                run: >-
+                    python -m
+                    pep517.build
+                    --source
+                    --binary
+                    --out-dir dist/
+                    .
             - name: Publish package to PyPI
             uses: pypa/gh-action-pypi-publish@master
             with:

--- a/contributing.md
+++ b/contributing.md
@@ -73,3 +73,8 @@ For instructions on running tests, please see the [Readme](https://github.com/NR
 The repository is equipped with a github action to build and publish new versions to PyPi.
 A maintainer can invoke this workflow by pushing a tag to the NREL/OpenOA reposiory with prefix "v", such as "v1.1.0".
 The action is defined in `.github/workflows/tags-to-pypi.yml`.
+
+```
+git tag -a v1.2.3 -m "Tag messgae for v1.2.3"
+git push origin v1.2.3
+```

--- a/contributing.md
+++ b/contributing.md
@@ -32,11 +32,12 @@ Pull requests must be made for any changes to be merged into release branches.
 They must include updated documentation and pass all unit tests and integration tests.
 In addition, code coverage should not be negatively affected by the pull request.
 
-**Scope:** Encapsulate the changes of ideally one, or potentially a couple, issues. It is greatly preferable
-to submit three small pull requests than it is to submit one large pull request. Write a complete description of these
-changes in the pull request body.
+**Scope:** Encapsulate the changes of ideally one, or potentially a couple, issues.
+It is greatly preferable to submit three small pull requests than it is to submit one large pull request.
+Write a complete description of these changes in the pull request body.
 
 **Tests:** Must pass all tests. Pull requests will be rejected if tests do not pass.
+Tests are automatically run through Github Actions for any pull request or push to the master or develop branches.
 
 **Documentation:** Include any relevant changes to inline documentation, as well as any changes to the RST files
 located in /sphinx.
@@ -66,3 +67,9 @@ create new tickets in this repository towards implementing the change.
 All code should be paired with a corresponding unit or integration test.
 OpenOA uses pytest and the built in unittest framework.
 For instructions on running tests, please see the [Readme](https://github.com/NREL/OpenOA/tree/develop#Testing).
+
+## Deploying a Package to PyPi
+
+The repository is equipped with a github action to build and publish new versions to PyPi.
+A maintainer can invoke this workflow by pushing a tag to the NREL/OpenOA reposiory with prefix "v", such as "v1.1.0".
+The action is defined in `.github/workflows/tags-to-pypi.yml`.

--- a/operational_analysis/__init__.py
+++ b/operational_analysis/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.1.2"
+__version__ = "1.1.3"
 
 import json
 import logging

--- a/operational_analysis/__init__.py
+++ b/operational_analysis/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.1.3"
+__version__ = "1.1.4"
 
 import json
 import logging

--- a/operational_analysis/__init__.py
+++ b/operational_analysis/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.1.4"
+__version__ = "2.0.0"
 
 import json
 import logging

--- a/operational_analysis/__init__.py
+++ b/operational_analysis/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.1"
+__version__ = "1.1.2"
 
 import json
 import logging

--- a/setup.py
+++ b/setup.py
@@ -26,43 +26,19 @@ def find_version(*file_paths):
     raise RuntimeError("Unable to find version string.")
 
 
-# PyTest Runners ##########
-
-class PyTest(TestCommand):
-    user_options = [('pytest-args=', 'a', "Arguments to pass to pytest")]
-
-    def initialize_options(self):
-        TestCommand.initialize_options(self)
-        self.pytest_args = ''
-
-    def run_tests(self):
-        import shlex
-        import pytest
-        errno = pytest.main(shlex.split(self.pytest_args + " -o python_files=test/*.py --cov=operational_analysis"))
-        sys.exit(errno)
-
-class PyTestIntegrate(PyTest):
-
-    def run_tests(self):
-        import shlex
-        import pytest
-        errno = pytest.main(shlex.split(self.pytest_args + " -o python_files=int_*.py --cov=operational_analysis"))
-        sys.exit(errno)
-
-class PyTestUnit(PyTest):
-
-    def run_tests(self):
-        import shlex
-        import pytest
-        errno = pytest.main(shlex.split(self.pytest_args + " -o python_files=test_*.py --cov=operational_analysis"))
-        sys.exit(errno)
-
+def read_file(filename):
+    this_directory = os.path.abspath(os.path.dirname(__file__))
+    with open(os.path.join(this_directory, filename), encoding='utf-8') as f:
+        f_text = f.read()
+    return f_text
 
 # setup.py main ##########
 
 setup(name='OpenOA',
       version=find_version("operational_analysis", "__init__.py"),
       description='A package for collecting and assigning wind turbine metrics',
+      long_description=read_file('readme.md'),
+      long_description_content_type='text/markdown',
       author='NREL PRUF OA Team',
       author_email='openoa@nrel.gov',
       url='https://github.com/NREL/OpenOA',
@@ -80,7 +56,5 @@ setup(name='OpenOA',
                         "EIA-python",
                         "requests"],
       tests_require=['pytest', 'pytest-cov'],
-      python_requires='>=3.6',
-      cmdclass={'test': PyTest, 'integrate':PyTestIntegrate, 'unit':PyTestUnit},
-      license='None'
+      python_requires='>=3.6'
       )


### PR DESCRIPTION
- Auth token for Pypi has been added as PYPI_PASSWORD secret.
- Pypi packaging action is added to .github workflows
- Documentation updated to include instructions on how to tag for pip package
- Version number bump to 2.0
- Removed pytestrunner from setup.py (we don't use it anymore)
- Added read_file function to setup.py which is used to read README.md as the pypi description.

A sample of what this looks like on PyPi is can be seen here: https://test.pypi.org/project/OpenOA/
The pypi url is: https:/pypi.org/project/OpenOA/ 
Happy to add folks as maintainers of the PyPi project (we should probably have at least two maintainers).
