### PR TITLE
replace geopandas with pyproj

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -21,18 +21,16 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+      shell: bash
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-      shell: bash
     - name: Unzip example data
       run: |
         yes | unzip examples/data/la_haute_borne.zip -d examples/data/la_haute_borne/
-      shell: bash
     - name: Test with pytest
       run: |
         pytest --cov=operational_analysis --cov-report=xml
-      shell: bash
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -9,10 +9,11 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        os: [ubuntu-latest, windows-latest]
+        python-version: [3.6, 3.8]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -32,7 +32,7 @@ jobs:
       shell: bash
     - name: Test with pytest
       run: |
-        pytest --cov=operational_analysis --cov-report=xml'
+        pytest --cov=operational_analysis --cov-report=xml
       shell: bash
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -25,10 +25,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+        yes
       shell: bash
     - name: Unzip example data
       run: |
-        yes | unzip examples/data/la_haute_borne.zip -d examples/data/la_haute_borne/
+        unzip examples/data/la_haute_borne.zip -d examples/data/la_haute_borne/
       shell: bash
     - name: Test with pytest
       run: |

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -25,7 +25,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        yes
       shell: bash
     - name: Unzip example data
       run: |

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -21,16 +21,18 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-      shell: bash
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+      shell: bash
     - name: Unzip example data
       run: |
         yes | unzip examples/data/la_haute_borne.zip -d examples/data/la_haute_borne/
+      shell: bash
     - name: Test with pytest
       run: |
-        pytest --cov=operational_analysis --cov-report=xml
+        pytest --cov=operational_analysis --cov-report=xml'
+      shell: bash
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -25,11 +25,14 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+      shell: bash
     - name: Unzip example data
       run: |
         yes | unzip examples/data/la_haute_borne.zip -d examples/data/la_haute_borne/
+      shell: bash
     - name: Test with pytest
       run: |
         pytest --cov=operational_analysis --cov-report=xml
+      shell: bash
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file. If you make a notable change to the project, please add a line describing the change to the "unreleased" section. The maintainers will make an effort to keep the [Github Releases](https://github.com/NREL/OpenOA/releases) page up to date with this changelog. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## [Unreleased]
-- Removed geopandas requirement to temporarily resolve GDAL dependency issues. Geopandas still needs to be installed if using the AssetData class.
+## [2.0.1 - 2020-10-13]
+- Replaced `GeoPandas` functionality with `pyproj` and `Shapely` for coordinate
+reference system conversion and distance measurements.
 
 ## [2.0.0 - 2020-08-11]
 - Switch to [semantic versioning](https://semver.org) from this release forward.

--- a/operational_analysis/__init__.py
+++ b/operational_analysis/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 
 import json
 import logging

--- a/operational_analysis/types/asset.py
+++ b/operational_analysis/types/asset.py
@@ -3,6 +3,7 @@ import itertools
 
 import numpy as np
 import pandas as pd
+from pyproj import Transformer
 from shapely.geometry import Point
 
 
@@ -88,21 +89,16 @@ class AssetData(object):
         Returns: None
             Sets asset 'geometry' column.
         """
-
-        import geopandas as gp
-
         if zone is None:
             # calculate zone
             if longitude is None:
                 longitude = self.df['longitude'].mean()
             zone = int(np.floor((180 + longitude) / 6.0)) + 1
 
-        self._asset = gp.GeoDataFrame(self._asset)
-        self._asset['geometry'] = self._asset.apply(lambda x: Point(x['longitude'], x['latitude']), 1)
-        self._asset.set_geometry('geometry')
-        self._asset.crs = {'init': srs}
-        self._asset = self._asset.to_crs(
-            "+proj=utm +zone=" + str(zone) + " +ellps=WGS84 +datum=WGS84 +units=m +no_defs")
+        to_crs = f"+proj=utm +zone={zone} +ellps=WGS84 +datum=WGS84 +units=m +no_defs"
+        transformer = Transformer.from_crs(srs.upper(), to_crs)
+        lats, lons = transformer.transform(self._asset["latitude"].values, self._asset["longitude"].values)
+        self._asset["geometry"] = [Point(lat, lon) for lat, lon in zip (lats, lons)]
 
     def calculate_nearest(self, active_turbine_ids, active_tower_ids):
         """Create or overwrite a column called 'nearest_turbine_id' or 'nearest_tower_id' which contains the asset id
@@ -132,11 +128,11 @@ class AssetData(object):
 
     def distance_matrix(self):
         ret = np.ones((self._asset.shape[0], self._asset.shape[0])) * -1
-        for i, j in itertools.permutations(self._asset.index, 2):
+        for i, j in itertools.combinations(self._asset.index, 2):
             point1 = self._asset.loc[i, 'geometry']
             point2 = self._asset.loc[j, 'geometry']
             distance = point1.distance(point2)
-            ret[i][j] = distance
+            ret[i, j] = ret[j, i] = distance
         return ret
 
     def asset_ids(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Requirements for the OpenOA software package
 eia-python>=1.22
-geopandas>=0.4.0
+pyproj>=2.6.1
 numpy>=1.15.4
 pandas>=0.23.4
 pygam>=0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # Requirements for the OpenOA software package
 eia-python>=1.22
 pyproj>=2.6.1
+shapely>=1.7.1
 numpy>=1.15.4
 pandas>=0.23.4
 pygam>=0.8.0

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,8 @@ setup(name='OpenOA',
                         "statsmodels",
                         "scikit_learn",
                         "EIA-python",
-                        "requests"],
+                        "requests",
+                        "pyproj"],
       tests_require=['pytest', 'pytest-cov'],
       python_requires='>=3.6'
       )

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,8 @@ setup(name='OpenOA',
                         "scikit_learn",
                         "EIA-python",
                         "requests",
-                        "pyproj"],
+                        "pyproj",
+                        "shapely"],
       tests_require=['pytest', 'pytest-cov'],
       python_requires='>=3.6'
       )


### PR DESCRIPTION
This pull request closes #40 .

After determining that `geopandas` was only used for the CRS conversion, and that it uses `pyproj` under the hood, I have simply replaced that functionality with a direct `pyproj` transformation. I can provide a test data set for coordinates to compare the old and new results, if needed, but I was coming up with the same results in my test case.

One oddity that I discovered is that in the `geopandas` CRS transformation the ordering of the latitude and longitude are reversed in the `AssetData._asset["geometry"]` column, so I have maintained the switched order of (latitude, longitude) instead of the originally encoded, prior to transformation, (longitude, latitude) ordering.

NOTE: I updated `requirements.txt`, but was unsure of updating the `setup.install_requires` part of `setup.py` because they didn't match up.