### PR TITLE
Adding asset data to example ENGIE project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 All notable changes to this project will be documented in this file. If you make a notable change to the project, please add a line describing the change to the "unreleased" section. The maintainers will make an effort to keep the [Github Releases](https://github.com/NREL/OpenOA/releases) page up to date with this changelog. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [UNRELEASED]
+- Added wind turbine asset data to example ENGIE project
 
 ## [2.2 - 2021-04-30]
 - IAV incorporation in AEP calculation

--- a/examples/project_ENGIE.py
+++ b/examples/project_ENGIE.py
@@ -230,3 +230,22 @@ class Project_Engie(PlantData):
         # Drop the fields we don't need
         self._reanalysis._product['era5'].df.drop(['Unnamed: 0',
                                 'datetime'], axis=1,inplace=True)
+
+        ##############
+        # ASSET DATA #
+        ############## 
+        self._asset.load(self._path,"la-haute-borne_asset_table","csv")
+        self._asset.rename_columns({"id":"Wind_turbine_name",
+                                    "latitude":"Latitude",
+                                    "longitude":"Longitude",
+                                    "rated_power_kw":"Rated_power",
+                                    "hub_height_m":"Hub_height_m",
+                                    "rotor_diameter_m":"Rotor_diameter_m"})
+
+        # Assign type to turbine for all assets
+        self._asset._asset['type'] = 'turbine'
+
+        # Drop renamed fields
+        self._asset._asset.drop(["Wind_turbine_name","Latitude","Longitude",
+                                "Rated_power","Hub_height_m",
+                                "Rotor_diameter_m"], axis=1,inplace=True)


### PR DESCRIPTION
This pull request adds an asset table csv file to the la_haute_borne.zip file in the examples folder and imports the asset data in the Project_ENGIE class. This will help contributors work on methods that use coordinates, rotor diameter, etc. for different turbines. resolves #145 