### PR TITLE
add gross energy to list of eya_data comment in gap analysis test

### DIFF
--- a/test/regression/int_eya_gap_analysis.py
+++ b/test/regression/int_eya_gap_analysis.py
@@ -11,7 +11,7 @@ class EYAGAPAnalysis(unittest.TestCase):
         np.random.seed(42)
         # Set up operational results data                
         oa_data = [448., 0.0493, 0.012, 477.8] 
-        # AEP (GWh/yr), availability loss (fraction), electrical loss (fraction), turbine ideal energy (GWh/yr)
+        # AEP (GWh/yr), gross energy (GWh/yr), availability loss (fraction), electrical loss (fraction), turbine ideal energy (GWh/yr)
 
         # Set up EYA estimates
         eya_data = [467.0, 597.14, 0.062, 0.024, 0.037, 0.011, 0.087] 


### PR DESCRIPTION
#### Main Issue
- Gross energy was ommited from comment describing elements in eya_data list.
#### Implementation
- Proper variable description provided in comment.
- Lines of code refactored within contribution guideline (max length = 120).
#### Remarks
- All tests passed after implementation.
- This implementation adds more clarity to the energy gap analysis test script.
-  Now merging into NREL:develop based on recommendation from @jordanperr 