### PR TITLE
Adding asset table dataframe setter

### DIFF
--- a/operational_analysis/types/asset.py
+++ b/operational_analysis/types/asset.py
@@ -192,3 +192,7 @@ class AssetData(object):
     @property
     def df(self):
         return self._asset
+
+    @df.setter
+    def df(self, value):
+        self._asset = value


### PR DESCRIPTION
This adds a simple setter for the asset table data frame in the AssetData class and addresses issue #150.