### PR TITLE
Add ommited variable description to gap analysis test

### DIFF
--- a/test/regression/int_eya_gap_analysis.py
+++ b/test/regression/int_eya_gap_analysis.py
@@ -11,7 +11,7 @@ class EYAGAPAnalysis(unittest.TestCase):
         np.random.seed(42)
         # Set up operational results data                
         oa_data = [448., 0.0493, 0.012, 477.8] 
-        # AEP (GWh/yr), availability loss (fraction), electrical loss (fraction), turbine ideal energy (GWh/yr)
+        # AEP (GWh/yr), gross energy (GWh/yr), availability loss (fraction), electrical loss (fraction), turbine ideal energy (GWh/yr)
 
         # Set up EYA estimates
         eya_data = [467.0, 597.14, 0.062, 0.024, 0.037, 0.011, 0.087] 

--- a/test/regression/int_eya_gap_analysis.py
+++ b/test/regression/int_eya_gap_analysis.py
@@ -11,11 +11,11 @@ class EYAGAPAnalysis(unittest.TestCase):
         np.random.seed(42)
         # Set up operational results data                
         oa_data = [448., 0.0493, 0.012, 477.8] 
-        # AEP (GWh/yr), gross energy (GWh/yr), availability loss (fraction), electrical loss (fraction), turbine ideal energy (GWh/yr)
+        # AEP (GWh/yr), availability loss (fraction), electrical loss (fraction), turbine ideal energy (GWh/yr)
 
         # Set up EYA estimates
         eya_data = [467.0, 597.14, 0.062, 0.024, 0.037, 0.011, 0.087] 
-        # AEP (GWh/yr), availability loss (fraction), electrical loss (fraction), turbine performance loss (fraction)
+        # AEP (GWh/yr), gross energy (GWh/yr), availability loss (fraction), electrical loss (fraction), turbine performance loss (fraction)
         # blade degradation loss (fraction), wake loss (fraction)
 
         # Creat gap analysis method object and run


### PR DESCRIPTION
Moved the gross energy variable description to the proper section. This was misplaced during last commit.