### PR TITLE
Remove SVM from description (issue #161)

### DIFF
--- a/operational_analysis/toolkits/machine_learning_setup.py
+++ b/operational_analysis/toolkits/machine_learning_setup.py
@@ -15,9 +15,9 @@ machine learning algorithms. Specifically, this toolkit constrains the following
 
     1. The learning algorithms available
 
-    These include extremely randomized trees, gradient boosting, a generalized
-    additive model (from pyGAM library, not SciKit-Learn) and a support vector
-    machine. These algorithms have been used extensively at NREL and have been
+    These include extremely randomized trees, gradient boosting, and a 
+    generalized additive model (from pyGAM library, not SciKit-Learn). 
+    These algorithms have been used extensively at NREL and have been
     found to provide robust results for a range of turbine and wind plant power
     analyses.
 


### PR DESCRIPTION
Reference to support vector machine algorithms is now removed from the machine learning setup class.

The actual implementation of SVMs was removed by Mike in March 2019, and he says this was done because it was SUPER slow and not very useful, at least under that implementation - hyperparmeter optimization took forever.