### PR TITLE
Maintainence/11 2021 fixing docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,25 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+   configuration: docs/conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
+
+# Optionally declare the Python requirements required to build your docs
+python:
+   install:
+   - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,7 +13,7 @@ build:
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-   configuration: docs/conf.py
+   configuration: sphinx/conf.py
 
 # If using Sphinx, optionally build your docs in additional formats such as PDF
 # formats:
@@ -22,4 +22,4 @@ sphinx:
 # Optionally declare the Python requirements required to build your docs
 python:
    install:
-   - requirements: docs/requirements.txt
+   - requirements: sphinx/requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,6 @@ bokeh==2.3.*
 # Not included in docs requirements
 pytest>=5.4.2
 pytest-cov>=2.8.1
-scikit_learn>=0.20.1
+scikit_learn>=0.20.1,<1.0
 matplotlib>=2.1.0
 requests>=2.21.0

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ from setuptools.command.test import test as TestCommand
 
 REQUIRED = [
     "statsmodels",
-    "scikit_learn>=0.20.1",
+    "scikit_learn>=0.20.1,<1.0",
     "requests>=2.21.0",
     "eia-python>=1.22",
     "pyproj>=2.6.1",

--- a/setup.py
+++ b/setup.py
@@ -92,5 +92,5 @@ setup(
     install_requires=REQUIRED,
     extras_require=EXTRAS,
     tests_require=TESTS,
-    python_requires=">=3.6, <=3.9",
+    python_requires=">=3.6, <=3.10",
 )

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -226,3 +226,21 @@ napoleon_google_docstring = True
 napoleon_use_param = False
 napoleon_use_ivar = False
 autoclass_content = "both"
+
+# -- Options for Autodoc
+
+autodoc_mock_imports = [
+    "statsmodels",
+    "sklearn",
+    "requests",
+    "eia",
+    "numpy",
+    "pandas",
+    "pygam",
+    "scipy",
+    "tqdm",
+    #    "matplotlib", ## These are actually required to generate the Bokeh plot in the pandas_plotting docs
+    #    "pyproj",
+    #    "shapely",
+    #    "bokeh",
+]

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -59,7 +59,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.napoleon",
     "sphinx.ext.todo",
-    "m2r",
+    "m2r2",
     "nbsphinx",
     "bokeh.sphinxext.bokeh_plot",
 ]

--- a/sphinx/requirements.txt
+++ b/sphinx/requirements.txt
@@ -11,3 +11,5 @@ nbmerge
 nbsphinx
 bokeh
 matplotlib
+pyproj
+shapely

--- a/sphinx/requirements.txt
+++ b/sphinx/requirements.txt
@@ -2,9 +2,11 @@
 # In addition to main requirements
 
 ipython
-m2r==0.2.1
-sphinx==2.0.0
-sphinxcontrib-napoleon==0.6.1
-sphinx_rtd_theme==0.2.4
+#docutils==0.17.1
+m2r2
+sphinx
+sphinxcontrib-napoleon
+sphinx_rtd_theme
 nbmerge
 nbsphinx
+bokeh

--- a/sphinx/requirements.txt
+++ b/sphinx/requirements.txt
@@ -10,3 +10,4 @@ sphinx_rtd_theme
 nbmerge
 nbsphinx
 bokeh
+matplotlib

--- a/sphinx/requirements.txt
+++ b/sphinx/requirements.txt
@@ -13,3 +13,4 @@ bokeh
 matplotlib
 pyproj
 shapely
+pandas


### PR DESCRIPTION
- Bumps python version to 3.9
- Bumps sphinx version (and most docs dependencies) to their most recent versions
- Bumps m2r to m2r2 (apparently m2r was abandoned). This is a library that converts markdown into rust, which is used by Sphinx.
- Adds .readthedocs.yaml config to repo which should make it easier to maintain the docs pipeline.
- Adds autodoc_mock_imports to sphinx config, which allows us to import python modules via autodoc without installing all the dependencies.
- Restrict scikit-learn<1.0, because the loss function of gbm has changed in v1.0, and this causes a small change in the results. Opening a separate issue to evaluate this.