### PR TITLE
Fix bug in `iter_validator` that failed with `None` values

### DIFF
--- a/openoa/plant.py
+++ b/openoa/plant.py
@@ -1575,12 +1575,12 @@ class PlantData:
         to_crs = f"+proj=utm +zone={utm_zone} +ellps=WGS84 +datum=WGS84 +units=m +no_defs"
         transformer = Transformer.from_crs(reference_system.upper(), to_crs)
         lats, lons = transformer.transform(
-            self._asset[self.metadata.asset.latitude].values,
-            self._asset[self.metadata.asset.longitude].values,
+            self.asset[self.metadata.asset.latitude].values,
+            self.asset[self.metadata.asset.longitude].values,
         )
 
         # TODO: Should this get a new name that's in line with the -25 convention?
-        self._asset["geometry"] = [Point(lat, lon) for lat, lon in zip(lats, lons)]
+        self.asset["geometry"] = [Point(lat, lon) for lat, lon in zip(lats, lons)]
 
     def update_column_names(self, to_original: bool = False) -> None:
         """Renames the columns of each dataframe to the be the keys from the

--- a/openoa/plant.py
+++ b/openoa/plant.py
@@ -68,62 +68,6 @@ ANALYSIS_REQUIREMENTS = {
 }
 
 
-def iter_validator(iter_type, item_types: Any | tuple[Any]) -> Callable:
-    """Helper function to generate iterable validators that will reduce the amount of
-    boilerplate code.
-
-    Parameters
-    ----------
-    iter_type : any iterable
-        The type of iterable object that should be validated.
-    item_types : Union[Any, Tuple[Any]]
-        The type or types of acceptable item types.
-
-    Returns
-    -------
-    Callable
-        The attr.validators.deep_iterable iterable and instance validator.
-    """
-    # If None is in the item_types, then convert it to a valid isinstance() argument
-    if item_types is None:
-        item_types = type(None)
-    elif isinstance(item_types, tuple):
-        if None in item_types:
-            ix = item_types.index(None)
-            item_types = list(item_types)
-            item_types[ix] = type(None)
-            item_types = tuple(item_types)
-
-    validator = attrs.validators.deep_iterable(
-        member_validator=attrs.validators.instance_of(item_types),
-        iterable_validator=attrs.validators.instance_of(iter_type),
-    )
-    return validator
-
-
-def analysis_type_validator(
-    instance: PlantData, attribute: attr.Attribute, value: list[str]
-) -> None:
-    """Validates the input from `PlantData` against the analysis requirements in
-    `ANALYSIS_REQUIREMENTS`. If there is an error, then it gets added to the
-    `PlantData._errors` dictionary to be raised in the post initialization hook.
-
-    Args:
-        instance (PlantData): The PlantData object.
-        attribute (attr.Attribute): The converted `analysis_type` attribute object.
-        value (list[str]): The input value from `analysis_type`.
-    """
-    if None in value:
-        warnings.warn("`None` was provided to `analysis_type`, so no validation will occur.")
-
-    valid_types = [*ANALYSIS_REQUIREMENTS] + ["all", None]
-    incorrect_types = set(value).difference(set(valid_types))
-    if incorrect_types:
-        raise ValueError(
-            f"{attribute.name} input: {incorrect_types} is invalid, must be one of 'all' or a combination of: {[*valid_types]}"
-        )
-
-
 def frequency_validator(
     actual_freq: str | None, desired_freq: str | None | set[str], exact: bool
 ) -> bool:
@@ -1181,7 +1125,10 @@ class PlantData:
     analysis_type: list[str] | None = attr.ib(
         default=None,
         converter=convert_to_list,
-        validator=[iter_validator(list, (str, type(None))), analysis_type_validator],
+        validator=attrs.validators.deep_iterable(
+            iterable_validator=attrs.validators.instance_of(list),
+            member_validator=attrs.validators.in_([*ANALYSIS_REQUIREMENTS] + ["all", None]),
+        ),
         on_setattr=[attr.setters.convert, attr.setters.validate],
     )
     scada: pd.DataFrame | None = attr.ib(default=None, converter=load_to_pandas)

--- a/test/regression/plantdata_validations.py
+++ b/test/regression/plantdata_validations.py
@@ -1,11 +1,12 @@
-import unittest
 import tempfile
+import unittest
 from pathlib import Path
 
+from examples import project_ENGIE
 from pandas.testing import assert_frame_equal
 
-from examples import project_ENGIE
-from openoa import PlantData
+from openoa import ANALYSIS_REQUIREMENTS, PlantData
+
 
 example_data_path = Path(__file__).parents[2].resolve() / "examples" / "data" / "la_haute_borne"
 example_data_path_str = str(example_data_path)
@@ -20,10 +21,13 @@ class TestPlantData(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.scada_df, cls.meter_df, cls.curtail_df, cls.asset_df, cls.reanalysis_dict = project_ENGIE.prepare(
-            path=example_data_path_str,
-            return_value="dataframes"
-        )
+        (
+            cls.scada_df,
+            cls.meter_df,
+            cls.curtail_df,
+            cls.asset_df,
+            cls.reanalysis_dict,
+        ) = project_ENGIE.prepare(path=example_data_path_str, return_value="dataframes")
 
     def setUp(self):
         """
@@ -31,7 +35,7 @@ class TestPlantData(unittest.TestCase):
         """
         self.plant = PlantData(
             analysis_type=None,  # No validation desired at this point in time
-            metadata=example_data_path_str+"/../plant_meta.yml",
+            metadata=example_data_path_str + "/../plant_meta.yml",
             scada=self.scada_df,
             meter=self.meter_df,
             curtail=self.curtail_df,
@@ -39,12 +43,38 @@ class TestPlantData(unittest.TestCase):
             reanalysis=self.reanalysis_dict,
         )
 
+    def test_analysis_type_values(self):
+        """
+        Test the acceptance of the valid inputs, except None
+        """
+        valid = [*ANALYSIS_REQUIREMENTS] + ["all", None]
+
+        self.plant.analysis_type = valid
+        self.assertTrue(self.plant.analysis_type == valid)
+
+        # Test a couple of edge cases to show that only valid inputs are allowed
+        # Add a mispelling
+        with self.assertRaises(ValueError):
+            self.plant.analysis_type = "Montecarloaep"
+
+        # Add a completely wrong value
+        with self.assertRaises(ValueError):
+            self.plant.analysis_type = "this is wrong"
+
     def test_validatePlantForAEP(self):
         """
         The example plant should validate for MonteCarloAEP analysis type
         """
         self.plant.analysis_type = "MonteCarloAEP"
         self.plant.validate()
+
+    def test_warnsForNone(self):
+        """
+        Test that None is valid, but raises a warning.
+        """
+        with self.assertWarns(UserWarning):
+            self.plant.analysis_type = None
+            self.plant.validate()
 
     def test_doesNotValidateForAll(self):
         """
@@ -58,11 +88,11 @@ class TestPlantData(unittest.TestCase):
         """
         Save this plant to a temporary directory, load it in, and make sure the data matches.
         """
-        ## Save
+        # Save
         data_path = tempfile.mkdtemp()
         self.plant.to_csv(save_path=data_path, with_openoa_col_names=True)
 
-        ## Load
+        # Load
         plant_loaded = PlantData(
             metadata=f"{data_path}/metadata.yml",
             scada=f"{data_path}/scada.csv",
@@ -70,10 +100,17 @@ class TestPlantData(unittest.TestCase):
             curtail=f"{data_path}/curtail.csv",
             status=f"{data_path}/scada.csv",
             asset=f"{data_path}/asset.csv",
-            reanalysis={"era5": f"{data_path}/reanalysis_era5.csv", "merra2": f"{data_path}/reanalysis_merra2.csv"},
+            reanalysis={
+                "era5": f"{data_path}/reanalysis_era5.csv",
+                "merra2": f"{data_path}/reanalysis_merra2.csv",
+            },
         )
 
-        assert_frame_equal(self.plant.scada, plant_loaded.scada, "Scada dataframe did not survive CSV save/loading process")
-        ## TODO, add more comprehensive checking.
-        ## - Check metadata
-        ## - Check all DFs equal
+        assert_frame_equal(
+            self.plant.scada,
+            plant_loaded.scada,
+            "Scada dataframe did not survive CSV save/loading process",
+        )
+        # TODO, add more comprehensive checking.
+        # - Check metadata
+        # - Check all DFs equal

--- a/test/regression/plantdata_validations.py
+++ b/test/regression/plantdata_validations.py
@@ -5,7 +5,8 @@ from pathlib import Path
 from examples import project_ENGIE
 from pandas.testing import assert_frame_equal
 
-from openoa import ANALYSIS_REQUIREMENTS, PlantData
+from openoa import PlantData
+from openoa.plant import ANALYSIS_REQUIREMENTS
 
 
 example_data_path = Path(__file__).parents[2].resolve() / "examples" / "data" / "la_haute_borne"
@@ -67,14 +68,6 @@ class TestPlantData(unittest.TestCase):
         """
         self.plant.analysis_type = "MonteCarloAEP"
         self.plant.validate()
-
-    def test_warnsForNone(self):
-        """
-        Test that None is valid, but raises a warning.
-        """
-        with self.assertWarns(UserWarning):
-            self.plant.analysis_type = None
-            self.plant.validate()
 
     def test_doesNotValidateForAll(self):
         """

--- a/test/unit/test_plant_data.py
+++ b/test/unit/test_plant_data.py
@@ -20,7 +20,6 @@ from openoa.plant import (
     StatusMetaData,
     CurtailMetaData,
     ReanalysisMetaData,
-    iter_validator,
     load_to_pandas,
     rename_columns,
     analysis_filter,
@@ -32,7 +31,6 @@ from openoa.plant import (
     frequency_validator,
     load_to_pandas_dict,
     compose_error_message,
-    analysis_type_validator,
 )
 
 
@@ -46,11 +44,6 @@ class AttrsDemoClass(FromDictMixin):
     y: float = field(converter=float, default=2.1)
     z: str = field(converter=str, default="z")
 
-    liststr: list[str] = field(
-        default=["qwerty", "asdf"],
-        validator=iter_validator(list, str),
-    )
-
 
 def test_FromDictMixin_defaults():
     # Test that the defaults set in the class definition are actually used
@@ -59,7 +52,6 @@ def test_FromDictMixin_defaults():
     defaults = {a.name: a.default for a in AttrsDemoClass.__attrs_attrs__ if a.default}
     assert cls.y == defaults["y"]
     assert cls.z == defaults["z"]
-    np.testing.assert_array_equal(cls.liststr, defaults["liststr"])
 
     # Test that defaults can be overwritten
     inputs = {"w": 0, "x": 1, "y": 4.5}
@@ -87,57 +79,7 @@ def test_FromDictMixin_custom():
         AttrsDemoClass.from_dict(inputs)
 
 
-def test_iter_validator():
-    # Test that the iter_validator ensures the inputs are a list of strings
-    # Check the correct values work
-    _ = AttrsDemoClass(w=0, x=1, liststr=["a", "b"])
-
-    # Check wrong member type
-    with pytest.raises(TypeError):
-        AttrsDemoClass(w=0, x=1, liststr=[4.3, 1])
-
-    # Check mixed member types
-    with pytest.raises(TypeError):
-        AttrsDemoClass(w=0, x=1, liststr=[4.3, "1"])
-
-    # Check wrong iterable type
-    with pytest.raises(TypeError):
-        AttrsDemoClass(w=0, x=1, liststr=("a", "b"))
-
-
 # Test all the standalone utility/helper methods
-
-
-def test_analysis_type_validator() -> None:
-    """Tests the `PlantData.analysis_type` validator method: `analysis_type_validator`.
-    The expected input for this method is `list[str | None]`, and all values that feed
-    into are converted into this format, so no tests will exist for checking the input
-    format.
-    """
-
-    instance = PlantData
-    attribute = attr.fields(PlantData).analysis_type
-
-    # Test the acceptance of the valid inputs, except None
-    valid = [*ANALYSIS_REQUIREMENTS] + ["all"]
-    assert analysis_type_validator(instance, attribute, valid) is None
-
-    # Test that None is valid, but raises a warning
-    with pytest.warns(UserWarning):
-        analysis_type_validator(instance, attribute, [None])
-
-    # Test that all valid cases work
-    valid.append(None)
-    assert analysis_type_validator(instance, attribute, valid) is None
-
-    # Test a couple of edge cases to show that only valid inputs are allowed
-    # Add a mispelling
-    with pytest.raises(ValueError):
-        analysis_type_validator(instance, attribute, valid + ["Montecarloaep"])
-
-    # Add a completely wrong value
-    with pytest.raises(ValueError):
-        analysis_type_validator(instance, attribute, valid + ["this is wrong"])
 
 
 def test_frequency_validator() -> None:


### PR DESCRIPTION
This is a small, isolated fix to address an issue for the `PlantData.analysis_type` validator doesn't correctly accept None as valid input. This fix converts an input of `None` to be `type(None)` in the actual validation so that a passed value of `None` will correctly validate to be a valid input.

@jordanperr this will solve the one issue we discussed earlier, and now allows the regression tests to fail somewhere else because of unrelated issues.