### PR TITLE
Generalizing Input Validation/Manipulation and Met Data Refactor

### DIFF
--- a/openoa/utils/_converters.py
+++ b/openoa/utils/_converters.py
@@ -5,7 +5,25 @@ throughout the utils subpackage.
 
 from __future__ import annotations
 
+from math import ceil
+
 import pandas as pd
+
+
+def _list_of_len(x: list, length: int) -> list:
+    """Converts a list of dynamic length to one of length `length` by repeating the elements of `x`
+    until the desired length is reached.
+
+    Args:
+        x (`list`): The list to be expanded.
+        length (`int`): The desired length of `x`
+
+    Returns:
+        list: A list of length `length` with repeating elements of `x`.
+    """
+    if (actual := len(x)) == length:
+        return x
+    return (x * ceil(length / actual))[:length]
 
 
 def convert_args_to_lists(length: int, *args) -> list[list]:
@@ -19,7 +37,7 @@ def convert_args_to_lists(length: int, *args) -> list[list]:
     Returns:
         list[list]: A list of lists of length `length` for each argument passed.
     """
-    return [a * length if isinstance(a, list) else [a] * length for a in args]
+    return [a if isinstance(a, list) else [a] * length for a in args]
 
 
 def df_to_series(data: pd.DataFrame, *args: str) -> tuple[pd.Series, ...]:

--- a/openoa/utils/_converters.py
+++ b/openoa/utils/_converters.py
@@ -1,0 +1,89 @@
+"""
+This is module for common data conversion and checking methods and decorators that are used
+throughout the utils subpackage.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def convert_args_to_lists(length: int, *args) -> list[list]:
+    """Convert method arguments to a list of length `length` for each argument passed.
+
+    Args:
+        length (int): The length of the argument list.
+        args: A series of arguments to be converted series of individual lists of length `length` for
+            each argument passed.
+
+    Returns:
+        list[list]: A list of lists of length `length` for each argument passed.
+    """
+    return [a * length if isinstance(a, list) else [a] * length for a in args]
+
+
+def df_to_series(data: pd.DataFrame, *args: str) -> tuple[pd.Series, ...]:
+    """Converts a `DataFrame` and dynamic number of column names to a an equal number of pandas `Series`
+    corresponding to the column names.
+
+    Args:
+        data (obj:`pandas.DataFrame`): The `DataFrame` object containg the column names in `args`.
+        args(obj:`str`): A dynamic number of strings that make up the column names that need to be
+            returned back as pandas `Series` objects.
+
+    Raises:
+        ValueError: Raised if any of the args passed is not contained in `data`.
+
+    Returns:
+        tuple[pandas.Series, ...]: A pandas `Series` for each of the column names passed in `args`
+    """
+    if len(invalid := set(args).difference(data.columns)) > 0:
+        raise ValueError(f"The following args are not columns of `data`: {invalid}")
+    return tuple(data.loc[:, col].copy() for col in args)
+
+
+def multiple_df_to_single_df(*args: pd.DataFrame, align_col: str | None = None) -> pd.DataFrame:
+    """Convert multiple `DataFrames` to a single `DataFrame` either along the index, when `align_col`
+    is None, or along the `align_col` when a value is provided.
+
+    Args:
+        args(:obj:`pandas.DataFrame`): A dynamic number of DataFrame inputs that need to be joined.
+        align_col(:obj:`str` | `None`, optional): The common column shared among `args`, or the index,
+            if `None`. Defaults to None.
+
+    Raises:
+        TypeError: Raised if any of the passed arguments isn't a pandas `DataFrame`
+        ValueError: Raised if a value is provided to args does not contain the `align_col`.
+
+    Returns:
+        pd.DataFrame: _description_
+    """
+    if not all(isinstance(el, pd.DataFrame) for el in args):
+        raise TypeError("At least one of the provided values was not a pandas Series")
+    if align_col is not None:
+        if not all(align_col in df for df in args):
+            raise ValueError(
+                f"At least of of the dataframes provided to *args does not contain the `align_col`: {align_col}"
+            )
+        args = [df.set_index(align_col) for df in args]
+
+    return pd.concat(args, join="outer", axis=1)
+
+
+def series_to_df(*args: pd.Series) -> pd.DataFrame:
+    """Convert a dynamic number of pandas `Series` to a single pandas `DataFrame` by concatenating
+    with an outer join, so the any missing values being filled with a NaN value, and each argument
+    becomes a column of the resulting `DataFrame`.
+
+    Args:
+        args(:obj:`pandas.Series`): A series of of pandas `Series` objects that share a common axis.
+
+    Returns:
+        pd.DataFrame: A single data structure combining all the passed arguments.
+    """
+    if not all(isinstance(el, pd.Series) for el in args):
+        raise TypeError("At least one of the provided values was not a pandas Series")
+    args = [el.to_frame() for el in args]
+    if len(args) > 1:
+        return multiple_df_to_single_df(*args)
+    return args[0]

--- a/openoa/utils/filters.py
+++ b/openoa/utils/filters.py
@@ -12,6 +12,8 @@ import scipy as sp
 import pandas as pd
 from sklearn.cluster import KMeans
 
+from openoa.utils._converters import series_to_df, convert_args_to_lists
+
 
 def _convert_to_df(data: pd.DataFrame | pd.Series, *args) -> tuple[bool, pd.DataFrame, list[Any]]:
     """Converts the passed `data` to a `pandas.DataFrame`, if needed, and converts the
@@ -49,18 +51,6 @@ def _convert_to_df(data: pd.DataFrame | pd.Series, *args) -> tuple[bool, pd.Data
     return to_series, data
 
 
-def _convert_single_input_to_list(length: int, *args) -> list[list]:
-    """Convert method arguments to a list of length `length` for each argument passed.
-
-    Args:
-        length (int): The length of the argument list.
-
-    Returns:
-        list[list]: A list of each argument passed.
-    """
-    return [a if isinstance(a, list) else [a] * length for a in args]
-
-
 def range_flag(
     data: pd.DataFrame | pd.Series,
     lower: float | list[float],
@@ -90,11 +80,11 @@ def range_flag(
             boolean entries.
     """
     # Prepare the inputs to be standardized for use with DataFrames
-    to_series, data, (upper, lower) = _convert_to_df(data, upper, lower)
+    to_series, data, (upper, lower) = series_to_df(data, upper, lower)
     if col is None:
         col = data.columns.tolist()
 
-    upper, lower = _convert_single_input_to_list(len(col), upper, lower)
+    upper, lower = convert_args_to_lists(len(col), upper, lower)
     if len(col) != len(lower) != len(upper):
         raise ValueError("The inputs to `col`, `above`, and `below` must be the same length.")
 
@@ -180,7 +170,7 @@ def std_range_flag(
     if col is None:
         col = data.columns.tolist()
 
-    threshold, *_ = _convert_single_input_to_list(len(col), threshold)
+    threshold, *_ = convert_args_to_lists(len(col), threshold)
     if len(col) != len(threshold):
         raise ValueError("The inputs to `col` and `threshold` must be the same length.")
 

--- a/openoa/utils/filters.py
+++ b/openoa/utils/filters.py
@@ -85,7 +85,7 @@ def range_flag(
     if col is None:
         col = data.columns.tolist()
 
-    upper, lower = convert_args_to_lists(len(col), upper, lower)
+    upper, lower = (len(col), upper, lower)
     if len(col) != len(lower) != len(upper):
         raise ValueError("The inputs to `col`, `above`, and `below` must be the same length.")
 
@@ -142,7 +142,7 @@ def unresponsive_flag(
 
 def std_range_flag(
     data: pd.DataFrame | pd.Series,
-    threshold: float = 2.0,
+    threshold: float | list[float] = 2.0,
     col: list[str] | None = None,
 ) -> pd.Series | pd.DataFrame:
     """Flag time stamps for which the measurement is outside of the threshold number of standard deviations

--- a/openoa/utils/filters.py
+++ b/openoa/utils/filters.py
@@ -15,42 +15,6 @@ from sklearn.cluster import KMeans
 from openoa.utils._converters import series_to_df, convert_args_to_lists
 
 
-def _convert_to_df(data: pd.DataFrame | pd.Series, *args) -> tuple[bool, pd.DataFrame, list[Any]]:
-    """Converts the passed `data` to a `pandas.DataFrame`, if needed, and converts the
-    additional method arguments to a list of the inputs if the passed value is a `pandas.Series`.
-
-    Args:
-        data (:obj:`pd.DataFrame` | `pd.Series`): The data to be filtered.
-
-    Raises:
-        TypeError: Raised if `data` is not a pandas `Series` or `DataFrame`.
-
-    Returns:
-        tuple[bool, pd.DataFrame, list[Any]]:
-            to_series (:obj:`bool`) is an indicator for if `data` will need to be converted
-                back to a `pandas.Series` object
-            data (:obj:`pandas.DataFrame`): `data` converted to a DataFrame, as needed.
-            args (:obj:`list[Any]`): A list of the original arguments passed, but now
-                encapsulated in individual lists, if the data passed was a `pandas.Series`,
-                otherwise, the original arguments.
-            `
-    """
-    if not isinstance(data, (pd.Series, pd.DataFrame)):
-        raise TypeError("Inputs to `data` must be a pandas Series or DataFrame object.")
-
-    if to_series := isinstance(data, pd.Series):
-        data = data.to_frame()
-
-        # Only convert the args if they're passed
-        if args:
-            args = [[a] for a in args]
-
-    # Only return args values if they're passed
-    if args:
-        return to_series, data, args
-    return to_series, data
-
-
 def range_flag(
     data: pd.DataFrame | pd.Series,
     lower: float | list[float],
@@ -85,7 +49,7 @@ def range_flag(
     if col is None:
         col = data.columns.tolist()
 
-    upper, lower = (len(col), upper, lower)
+    upper, lower = convert_args_to_lists(len(col), upper, lower)
     if len(col) != len(lower) != len(upper):
         raise ValueError("The inputs to `col`, `above`, and `below` must be the same length.")
 
@@ -119,7 +83,8 @@ def unresponsive_flag(
             boolean entries.
     """
     # Prepare the inputs to be standardized for use with DataFrames
-    to_series, data = _convert_to_df(data)
+    if to_series := isinstance(data, pd.Series):
+        data = series_to_df(data)
     if col is None:
         col = data.columns.tolist()
     if not isinstance(threshold, int):
@@ -167,7 +132,8 @@ def std_range_flag(
             boolean entries.
     """
     # Prepare the inputs to be standardized for use with DataFrames
-    to_series, data = _convert_to_df(data)
+    if to_series := isinstance(data, pd.Series):
+        data = series_to_df(data)
     if col is None:
         col = data.columns.tolist()
 

--- a/openoa/utils/filters.py
+++ b/openoa/utils/filters.py
@@ -80,7 +80,8 @@ def range_flag(
             boolean entries.
     """
     # Prepare the inputs to be standardized for use with DataFrames
-    to_series, data, (upper, lower) = series_to_df(data, upper, lower)
+    if to_series := isinstance(data, pd.Series):
+        data = series_to_df(data)
     if col is None:
         col = data.columns.tolist()
 

--- a/openoa/utils/met_data_processing.py
+++ b/openoa/utils/met_data_processing.py
@@ -335,7 +335,8 @@ def compute_veer(
     Returns:
         veer(:obj:`array`): veer (deg/m)
     """
-
+    if data is not None:
+        wind_a, wind_b = df_to_series(data, wind_a, wind_b)
     # Calculate wind direction change
     delta_dir = wind_b - wind_a
 

--- a/openoa/utils/met_data_processing.py
+++ b/openoa/utils/met_data_processing.py
@@ -2,6 +2,8 @@
 This module provides methods for processing meteorological data.
 """
 
+from __future__ import annotations
+
 import warnings
 
 import numpy as np
@@ -9,12 +11,13 @@ import pandas as pd
 import scipy.constants as const
 
 
-def compute_wind_direction(u, v):
+def compute_wind_direction(u: pd.Series | str, v: pd.Series | str, data: pd.DataFrame = None):
     """Compute wind direction given u and v wind vector components
 
     Args:
-        u(:obj:`pandas.Series`): the zonal component of the wind; units of m/s
-        v(:obj:`pandas.Series`): the meridional component of the wind; units of m/s
+        u(:obj:`pandas.Series` | `str`): the zonal component of the wind; units of m/s
+        v(:obj:`pandas.Series` | `str`): the meridional component of the wind; units of m/s
+        data(:obj:`pandas.DataFrame`): The pandas DataFrame containg the columns `u` and `v`
 
     Returns:
         :obj:`pandas.Series`: wind direction; units of degrees
@@ -146,6 +149,7 @@ def compute_turbulence_intensity(mean_col, std_col):
     """
     return std_col / mean_col
 
+
 def compute_shear(
     data: pd.DataFrame, ws_heights: dict, return_reference_values: bool = False
 ) -> np.array:
@@ -154,7 +158,7 @@ def compute_shear(
     The shear coefficient is obtained by evaluating the expression for an OLS regression coefficient.
 
     Updated version targeting OpenOA V3 due to the following api breaking change:
-        - Removal of ref_col, instead, returning the reference column used 
+        - Removal of ref_col, instead, returning the reference column used
 
     Args:
         data(:obj:`pandas.DataFrame`): dataframe with wind speed columns
@@ -220,6 +224,7 @@ def compute_shear(
         u_ref = np.exp(np.nanmean(u, axis=1))
 
         return alpha, z_ref, u_ref
+
 
 def extrapolate_windspeed(v1, z1: float, z2: float, shear):
     """

--- a/openoa/utils/met_data_processing.py
+++ b/openoa/utils/met_data_processing.py
@@ -28,7 +28,7 @@ def compute_wind_direction(
             in m/s, or the name of the column in `data`.
         v(:obj:`pandas.Series` | `str`): A pandas `Series` of the meridional component of the wind,
             in m/s, or the name of the column in `data`.
-        data(:obj:`pandas.DataFrame`): The pandas DataFrame containg the columns `u` and `v`.
+        data(:obj:`pandas.DataFrame`): The pandas `DataFrame` containg the columns `u` and `v`.
 
     Returns:
         :obj:`pandas.Series`: wind direction; units of degrees
@@ -46,10 +46,15 @@ def compute_u_v_components(
     """Compute vector components of the horizontal wind given wind speed and direction
 
     Args:
-        wind_speed(pandas.Series): A pandas `Series` of the horizontal wind speed, in m/s, or the
-            name of the column in `data`.
-        wind_dir(pandas.Series): A pandas `Series` of the wind direction, in degrees, or the name of
-            the column in `data`.
+        wind_speed(:obj:`pandas.Series` | `str`): A pandas `Series` of the horizontal wind speed, in
+            m/s, or the name of the column in `data`.
+        wind_dir(:obj:`pandas.Series` | `str`): A pandas `Series` of the wind direction, in degrees,
+            or the name of the column in `data`.
+        data(:obj:`pandas.DataFrame`): The pandas `DataFrame` containg the columns `wind_speed` and
+            `wind_direction`.
+
+    Raises:
+        ValueError: Raised if any of the `wind_speed` or `wind_dir` values are negative.
 
     Returns:
         (tuple):
@@ -59,9 +64,10 @@ def compute_u_v_components(
     if data is not None:
         wind_speed, wind_dir = df_to_series(data, wind_speed, wind_dir)
 
-    # Send exception if any negative data found
-    if (wind_speed[wind_speed < 0].size > 0) | (wind_dir[wind_dir < 0].size > 0):
-        raise Exception("Some of your wind speed or direction data is negative. Check your data")
+    if np.any(wind_speed < 0):
+        raise ValueError("Negative values exist in the `wind_speed` data.")
+    if np.any(wind_dir < 0):
+        raise ValueError("Negative values exist in the `wind_dir` data.")
 
     u = np.round(-wind_speed * np.sin(wind_dir * np.pi / 180), 10)
     v = np.round(-wind_speed * np.cos(wind_dir * np.pi / 180), 10)
@@ -85,9 +91,18 @@ def compute_air_density(
     Humidity values are optional. According to the IEC a humiditiy of 50% (0.5) is set as default value.
 
     Args:
-        temp_col(:obj:`array-like`): array with temperature values; units of Kelvin
-        pres_col(:obj:`array-like`): array with pressure values; units of Pascals
-        humi_col(:obj:`array-like`): optional array with relative humidity values; dimensionless (range 0 to 1)
+        temp_col(:obj:`pandas.Series` | `str`): A pandas `Series` of the temperature values, in
+            Kelvin, or the name of the column in `data`.
+        pres_col(:obj:`pandas.Series` | `str`): A pandas `Series` of the pressure values, in Pascals,
+            or the name of the column in `data`.
+        humi_col(:obj:`pandas.Series` | `str`): An optional pandas `Series` of the relative humidity
+            values, as a decimal in the range (0, 1), or the name of the column in `data`, by default
+            None.
+        data(:obj:`pandas.DataFrame`): The pandas `DataFrame` containg the columns `temp_col` and
+            `pres_col`, and optionally `humi_col`.
+
+    Raises:
+        ValueError: Raised if any of the `temp_col` or `pres_col`, or `humi_col` values are negative.
 
     Returns:
         :obj:`pandas.Series`: Rho, calcualted air density; units of kg/m3
@@ -100,11 +115,12 @@ def compute_air_density(
     else:
         rel_humidity = np.full(temp_col.shape[0], 0.5)
 
-    # Send exception if any negative data found
-    if np.any(temp_col < 0) | np.any(pres_col < 0) | np.any(rel_humidity < 0):
-        raise Exception(
-            "Some of your temperature, pressure or humidity data is negative. Check your data."
-        )
+    if np.any(temp_col < 0):
+        raise ValueError("Negative values exist in the temperature data.")
+    if np.any(pres_col < 0):
+        raise ValueError("Negative values exist in the pressure data.")
+    if np.any(rel_humidity < 0):
+        raise ValueError("Negative values exist in the humidity data.")
 
     rho = (1 / temp_col) * (
         pres_col / R - rel_humidity * (0.0000205 * np.exp(0.0631846 * temp_col)) * (1 / R - 1 / Rw)
@@ -113,65 +129,94 @@ def compute_air_density(
     return rho
 
 
-def pressure_vertical_extrapolation(p0, temp_avg, z0, z1):
+def pressure_vertical_extrapolation(
+    p0: pd.Series | str,
+    temp_avg: pd.Series | str,
+    z0: pd.Series | str,
+    z1: pd.Series | str,
+    data: pd.DataFrame = None,
+) -> pd.Series:
     """
     Extrapolate pressure from height z0 to height z1 given the average temperature in the layer.
     The hydostatic equation is used to peform the extrapolation.
 
     Args:
-        p0(:obj:`pandas.Series`): pressure at height z0; units of Pascals
-        temp_avg(:obj:`pandas.Series`): mean temperature between z0 and z1; units of Kelvin
-        z0(:obj:`pandas.Series`): height above surface; units of meters
-        z1(:obj:`pandas.Series`): extrapolation height; units of meters
+        p0(:obj:`pandas.Series`): A pandas `Series` of the pressure at height z0, in Pascals, or the
+            name of the column in `data`.
+        temp_avg(:obj:`pandas.Series`): A pandas `Series` of the mean temperature between z0 and z1,
+            in Kelvin, or the name of the column in `data`.
+        z0(:obj:`pandas.Series`): A pandas `Series` of the height above surface, in meters, or the
+            name of the column in `data`.
+        z1(:obj:`pandas.Series`): A pandas `Series` of the extrapolation height, in meters, or the
+            name of the column in `data`.
+        data(:obj:`pandas.DataFrame`): The pandas `DataFrame` containg the columns `p0`, `temp_avg`,
+            `z0`, and `z1`.
+
+    Raises:
+        ValueError: Raised if any of the `p0` or `temp_avg` values are negative.
 
     Returns:
-        :obj:`pandas.Series`: p1, extrapolated pressure at z1; units of Pascals
+        :obj:`pandas.Series`: p1, extrapolated pressure at z1, in Pascals
     """
-    # Send exception if any negative data found
-    if (p0[p0 < 0].size > 0) | (temp_avg[temp_avg < 0].size > 0):
-        raise Exception("Some of your temperature of pressure data is negative. Check your data")
+    if data is not None:
+        p0, temp_avg, z0, z1 = df_to_series(data, p0, temp_avg, z0, z1)
+
+    if np.any(p0 < 0):
+        raise ValueError("Negative values exist in the `p0` data.")
+    if np.any(temp_avg < 0):
+        raise ValueError("Negative values exist in the `temp_avg` data.")
 
     p1 = p0 * np.exp(-const.g * (z1 - z0) / R / temp_avg)  # Pressure at z1
-
     return p1
 
 
-def air_density_adjusted_wind_speed(wind_col, density_col):
+def air_density_adjusted_wind_speed(
+    wind_col: pd.Series | str, density_col: pd.Series | str, data: pd.DataFrame = None
+) -> pd.Series:
     """
     Apply air density correction to wind speed measurements following IEC-61400-12-1 standard
 
     Args:
-        wind_col(:obj:`str`): array containing the wind speed data; units of m/s
-        density_col(:obj:`str`): array containing the air density data; units of kg/m3
+        wind_col(:obj:`pandas.Series` | `str`): A pandas `Series` containing the wind speed data,
+            in m/s, or the name of the column in `data`
+        density_col(:obj:`pandas.Series` | `str`): A pandas `Series` containing the air density data,
+            in kg/m3, or the name of the column in `data`
+        data(:obj:`pandas.DataFrame`): The pandas `DataFrame` containg the columns `wind_col` and
+            `density_col`.
 
     Returns:
-        :obj:`pandas.Series`: density-adjusted wind speeds; units of m/s
+        :obj:`pandas.Series`: density-adjusted wind speeds, in m/s
     """
-    rho_mean = density_col.mean()  # Mean air density across sample
-    dens_adjusted_ws = wind_col * np.power(
-        density_col / rho_mean, 1.0 / 3
-    )  # Density adjusted wind speeds
+    if data is not None:
+        wind_col, density_col = df_to_series(data, wind_col, density_col)
 
-    return dens_adjusted_ws
+    return wind_col * np.power(density_col / density_col.mean(), 1.0 / 3)
 
 
-def compute_turbulence_intensity(mean_col, std_col):
+def compute_turbulence_intensity(
+    mean_col: pd.Series | str, std_col: pd.Series | str, data: pd.DataFrame = None
+) -> pd.Series:
     """
     Compute turbulence intensity
 
     Args:
-        mean_col(:obj:`array`): array containing the wind speed mean  data; units of m/s
-        std_col(:obj:`array`): array containing the wind speed standard deviation data; units of m/s
+        mean_col(:obj:`pandas.Series` | `str`): A pandas `Series` containing the wind speed mean
+            data, in m/s, or the name of the column in `data`.
+        std_col(:obj:`pandas.Series` | `str`): A pandas `Series` containing the wind speed standard
+            deviation data, in m/s, or the name of the column in `data`.
+        data(:obj:`pandas.DataFrame`): The pandas `DataFrame` containg the columns `mean_col` and `std_col`.
 
     Returns:
-        :obj:`array`: turbulence intensity, (unitless ratio)
+        :obj:`pd.Series`: turbulence intensity, (unitless ratio)
     """
+    if data is not None:
+        mean_col, std_col = df_to_series(data, mean_col, std_col)
     return std_col / mean_col
 
 
 def compute_shear(
-    data: pd.DataFrame, ws_heights: dict, return_reference_values: bool = False
-) -> np.array:
+    data: pd.DataFrame, ws_heights: dict[str, float], return_reference_values: bool = False
+) -> pd.Series | tuple[pd.Series, float, pd.Series]:
     """
     Computes shear coefficient between wind speed measurements using the power law.
     The shear coefficient is obtained by evaluating the expression for an OLS regression coefficient.
@@ -180,31 +225,31 @@ def compute_shear(
         - Removal of ref_col, instead, returning the reference column used
 
     Args:
-        data(:obj:`pandas.DataFrame`): dataframe with wind speed columns
-        ws_heights(:obj:`dict`): keys are strings of columns in <data> containing wind speed data, values are
-                                 associated sensor heights (m)
-        return_reference_values(:obj: `bool`): If True, this function returns a three element tuple where the
-                                               first element is the array of shear exponents, the second element
-                                               is the reference height (float), and the third element is the
-                                               reference wind speed (array). These reference values can be used
-                                               for extrapolating wind speed. Defaults to False.
+        data(:obj:`pandas.DataFrame`): A pandas `DataFrame` with wind speed columns that correspond
+            to the keys of `ws_heights`.
+        ws_heights(:obj:`dict[str, float]`): A dictionary with wind speed column names of `data` as
+            keys and their respective sensor heights (m) as values.
+        return_reference_values(:obj: `bool`): If True, this function returns a three element tuple
+            where the first element is the array of shear exponents, the second element is the
+            reference height (float), and the third element is the array of reference wind speeds.
+            These reference values can be used for extrapolating wind speed. Defaults to False.
 
     Returns:
         If return_reference_values is False (default):
-        :obj:`numpy.array`: shear coefficient (unitless)
+        :obj:`pandas.Series`: shear coefficient (unitless)
 
         If return_reference_values is True:
-        :obj:`tuple`: (shear coefficient (unitless), reference height (m), reference wind speed)
+        :obj:`tuple[pandas.Series, float, pandas.Series]`: The shear coefficient (unitless), reference
+            height (m), and reference wind speed.
 
     """
 
-    # create "u" 2-D array; where element [i,j] is the wind speed measurement at the ith timestep and jth sensor height
-    u: np.ndarray = data[ws_heights.keys()].to_numpy()
+    # Extract the wind speed columns from `data` and create "u" 2-D array; where element
+    # [i,j] is the wind speed measurement at the ith timestep and jth sensor height
+    u: np.ndarray = np.column_stack(df_to_series(data, *ws_heights))
 
     # create "z" 2_D array; columns are filled with the sensor height
-    n: int = len(data)
-    heights: list = [np.full(n, height) for height in ws_heights.values()]
-    z: np.ndarray = np.column_stack(tuple(heights))
+    z: np.ndarray = np.repeat([[*ws_heights.values()]], len(data), axis=0)
 
     # take log of z & u
     with warnings.catch_warnings():  # suppress log division by zero warning.
@@ -245,32 +290,47 @@ def compute_shear(
         return alpha, z_ref, u_ref
 
 
-def extrapolate_windspeed(v1, z1: float, z2: float, shear):
+def extrapolate_windspeed(
+    v1: pd.Series | str, z1: float, z2: float, shear: pd.Series | str, data: pd.DataFrame = None
+):
     """
     Extrapolates wind speed vertically using the Power Law.
 
     Args:
-        v1(:obj: `pandas.Series` | `numpy.array` | `float`): Wind speed measurements at the reference height.
+        v1(:obj: `pandas.Series` | `float` | `str`): A pandas `Series` of the wind
+            speed measurements at the reference height, or the name of the column in `data`.
         z1(:obj:`float`): Height of reference wind speed measurements; units in meters
         z2(:obj:`float`): Target extrapolation height; units in meters
-        shear(:obj: `pandas.Series` | `numpy.array` | `float`): Shear value(s)
+        shear(:obj: `pandas.Series` | `float` | `str`): A pandas `Series` of the shear
+            values, or the name of the column in `data`.
+        data(:obj:`pandas.DataFrame`): The pandas `DataFrame` containg the columns `v1` and `shear`.
 
     Returns:
         :obj: (`pandas.Series` | `numpy.array` | `float`): Wind speed extrapolated to target height.
     """
+    if data is not None:
+        v1, shear = df_to_series(data, v1, shear)
+    return v1 * (z2 / z1) ** shear
 
-    target_ws = v1 * (z2 / z1) ** shear
 
-    return target_ws
-
-
-def compute_veer(wind_a, height_a, wind_b, height_b):
+def compute_veer(
+    wind_a: pd.Series | str,
+    height_a: float,
+    wind_b: pd.Series | str,
+    height_b: float,
+    data: pd.DataFrame = None,
+):
     """
     Compute veer between wind direction measurements
 
     Args:
-        wind_a, wind_b(:obj:`array`): arrays containing the wind direction mean data; units of deg
-        height_a, height_b(:obj:`array`): sensor heights (m)
+        wind_a(:obj:`pandas.Series` | `str`): A pandas `Series` containing the wind direction mean
+            data, in degrees, or the name of the column in `data`.
+        height_a(:obj:`float`): sensor height for `wind_a`
+        wind_b(:obj:`pandas.Series` | `str`): A pandas `Series` containing the wind direction mean
+            data, in degrees, or the name of the column in `data`.
+        height_b(:obj:`float`): sensor height for `wind_b`
+        data(:obj:`pandas.DataFrame`): The pandas `DataFrame` containg the columns `wind_a`, and `wind_b`.
 
     Returns:
         veer(:obj:`array`): veer (deg/m)
@@ -279,8 +339,9 @@ def compute_veer(wind_a, height_a, wind_b, height_b):
     # Calculate wind direction change
     delta_dir = wind_b - wind_a
 
-    # Convert absolute values greater than 180 to normal range
-    delta_dir[delta_dir > 180] = delta_dir[delta_dir > 180] - 360.0
-    delta_dir[delta_dir <= (-180)] = delta_dir[delta_dir <= (-180)] + 360.0
+    # Convert absolute values greater than outside 180 to a normal range
+    delta_dir = delta_dir.where(delta_dir <= 180, delta_dir - 360.0).where(
+        delta_dir > -180, delta_dir + 360.0
+    )
 
     return delta_dir / (height_b - height_a)

--- a/openoa/utils/met_data_processing.py
+++ b/openoa/utils/met_data_processing.py
@@ -13,7 +13,7 @@ import scipy.constants as const
 from openoa.utils._converters import df_to_series
 
 
-# Define constants
+# Define constants used in some of the methods
 R = 287.058  # Gas constant for dry air, units of J/kg/K
 Rw = 461.5  # Gas constant of water vapour, unit J/kg/K
 
@@ -106,11 +106,8 @@ def compute_air_density(
             "Some of your temperature, pressure or humidity data is negative. Check your data."
         )
 
-    R_const = 287.05  # Gas constant for dry air, units of J/kg/K
-    Rw_const = 461.5  # Gas constant of water vapour, unit J/kg/K
     rho = (1 / temp_col) * (
-        pres_col / R_const
-        - rel_humidity * (0.0000205 * np.exp(0.0631846 * temp_col)) * (1 / R_const - 1 / Rw_const)
+        pres_col / R - rel_humidity * (0.0000205 * np.exp(0.0631846 * temp_col)) * (1 / R - 1 / Rw)
     )
 
     return rho
@@ -134,8 +131,7 @@ def pressure_vertical_extrapolation(p0, temp_avg, z0, z1):
     if (p0[p0 < 0].size > 0) | (temp_avg[temp_avg < 0].size > 0):
         raise Exception("Some of your temperature of pressure data is negative. Check your data")
 
-    R_const = 287.058  # Gas constant for dry air, units of J/kg/K
-    p1 = p0 * np.exp(-const.g * (z1 - z0) / R_const / temp_avg)  # Pressure at z1
+    p1 = p0 * np.exp(-const.g * (z1 - z0) / R / temp_avg)  # Pressure at z1
 
     return p1
 

--- a/test/regression/long_term_monte_carlo_aep.py
+++ b/test/regression/long_term_monte_carlo_aep.py
@@ -5,8 +5,9 @@ import numpy as np
 import pandas as pd
 import pytest
 from numpy import testing as nptest
-from openoa.analysis import aep
 from examples import project_ENGIE, example_data_path_str
+
+from openoa.analysis import aep
 
 
 def reset_prng():
@@ -15,7 +16,6 @@ def reset_prng():
 
 
 class TestLongTermMonteCarloAEP(unittest.TestCase):
-
     def setUp(self):
         """
         Python Unittest setUp method.
@@ -29,8 +29,12 @@ class TestLongTermMonteCarloAEP(unittest.TestCase):
         # Set up a new project with modified reanalysis start and end dates
         self.project_rean = project_ENGIE.prepare(example_data_path_str)
 
-        self.project_rean.reanalysis["merra2"] = self.project_rean.reanalysis["merra2"].loc[:'2019-04-15 12:30']
-        self.project_rean.reanalysis["era5"] = self.project_rean.reanalysis["era5"].loc['1999-01-15 12:00':]
+        self.project_rean.reanalysis["merra2"] = self.project_rean.reanalysis["merra2"].loc[
+            :"2019-04-15 12:30"
+        ]
+        self.project_rean.reanalysis["era5"] = self.project_rean.reanalysis["era5"].loc[
+            "1999-01-15 12:00":
+        ]
 
     def test_monthly_inputs(self):
         """
@@ -528,7 +532,7 @@ class TestLongTermMonteCarloAEP(unittest.TestCase):
 
     def check_simulation_results_etr_daily(self, s):
         # Make sure AEP results are consistent to six decimal places
-        expected_results = [12.938536, 8.561798, 1.334704, 5.336189, 0.057874, 11.339976]
+        expected_results = [12.938535, 8.561778, 1.334704, 5.33619, 0.057874, 11.339982]
 
         calculated_results = [
             s.aep_GWh.mean(),

--- a/test/unit/test_filter_toolkit.py
+++ b/test/unit/test_filter_toolkit.py
@@ -43,7 +43,7 @@ class SimpleFilters(unittest.TestCase):
         with self.assertRaises(ValueError):
             filters.range_flag(x, [2], [6, 5], ["a"])
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             filters.range_flag(x, [2], [6], ["a", "b"])
 
         with self.assertRaises(ValueError):
@@ -179,7 +179,7 @@ class SimpleFilters(unittest.TestCase):
             ],
             columns=["a", "b", "c"],
         )
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             filters.std_range_flag(x, [2], col=["b", "c"])
 
     # TODO: Test more code paths in bin_filter

--- a/test/unit/test_filter_toolkit.py
+++ b/test/unit/test_filter_toolkit.py
@@ -43,7 +43,7 @@ class SimpleFilters(unittest.TestCase):
         with self.assertRaises(ValueError):
             filters.range_flag(x, [2], [6, 5], ["a"])
 
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             filters.range_flag(x, [2], [6], ["a", "b"])
 
         with self.assertRaises(ValueError):
@@ -179,7 +179,7 @@ class SimpleFilters(unittest.TestCase):
             ],
             columns=["a", "b", "c"],
         )
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             filters.std_range_flag(x, [2], col=["b", "c"])
 
     # TODO: Test more code paths in bin_filter

--- a/test/unit/test_met_data_processing_toolkit.py
+++ b/test/unit/test_met_data_processing_toolkit.py
@@ -3,6 +3,7 @@ import unittest
 import numpy as np
 import pandas as pd
 from numpy import testing as nptest
+
 from openoa.utils import met_data_processing as mt
 
 
@@ -38,7 +39,7 @@ class SimpleMetProcessing(unittest.TestCase):
         pres = np.arange(90000, 110000, 5000)
 
         rho = mt.compute_air_density(temp, pres)  # Test result
-        rho_ans = np.array([1.11744, 1.1581, 1.19706, 1.23427])  # Expected result
+        rho_ans = np.array([1.11741, 1.15807, 1.19702, 1.23424])  # Expected result
 
         nptest.assert_array_almost_equal(rho, rho_ans, decimal=5)
 

--- a/test/unit/test_met_data_processing_toolkit.py
+++ b/test/unit/test_met_data_processing_toolkit.py
@@ -142,8 +142,8 @@ class SimpleMetProcessing(unittest.TestCase):
         nptest.assert_allclose(computed_v2, expected_v2)
 
     def test_compute_veer(self):
-        wind_low = np.linspace(2.0, 10.0, 10)
-        wind_high = np.linspace(8.0, 25.0, 10)
+        wind_low = pd.Series(np.linspace(2.0, 10.0, 10))
+        wind_high = pd.Series(np.linspace(8.0, 25.0, 10))
         height_low = 30.0
         height_high = 80.0
 


### PR DESCRIPTION
This PR starts generalizing the data handling methods for allowing the OpenOA utilities to accept both pandas Series and DataFrame objects, and refactors openoa.utils.met_data_processing methods to accept both data types. There is a slight modification to the gas constant as there were two slightly different version in use, so some regression tests have been updated for the use of the version that has higher accuracy.

@jordanperr I've tagged you here, to give it a once over, and I'm keeping these types of PRs more brief to ensure it's not overwhelming. Additionally, the changes in here are similar to the changes from #198, so there aren't any fundamental redesigns.