### PR TITLE
Refactor the Unit Conversion Utilities

### DIFF
--- a/test/unit/test_unit_conversion_toolkit.py
+++ b/test/unit/test_unit_conversion_toolkit.py
@@ -3,6 +3,7 @@ import unittest
 import numpy as np
 import pandas as pd
 from numpy import testing as nptest
+
 from openoa.utils import unit_conversion
 
 
@@ -25,35 +26,45 @@ class SimpleUnitConversionTests(unittest.TestCase):
 
     def test_compute_gross_energy(self):
         # Set some test values
-        net = np.array([[1, 1, 1], [0, 1, 1], [1, 1, 1]])
-        avail = np.array([[0.05, 0.08, 0.2], [0.05, 0.9, 0.2], [0.05, 0.9, 0]])
-        curt = np.array([[0.05, 0.05, 0.05], [0.05, 0.2, 0.05], [0.05, -0.1, 0.05]])
+        net = pd.DataFrame([[1, 0, 1], [1, 1, 1], [1, 1, 1]], columns=["test1", "test2", "test3"])
+        avail = pd.DataFrame(
+            [[0.05, 0.05, 0.05], [0.08, 0.9, 0.9], [0.2, 0.2, 0]],
+            columns=["test1", "test2", "test3"],
+        )
+        avail = pd.DataFrame(
+            [[0.05, 0.05, 0.05], [0.08, 0.9, 0.9], [0.2, 0.2, 0]],
+            columns=["test1", "test2", "test3"],
+        )
+        curtail = pd.DataFrame(
+            [[0.05, 0.05, 0.05], [0.05, 0.2, -0.1], [0.05, 0.05, 0.05]],
+            columns=["test1", "test2", "test3"],
+        )
 
         # Make sure different combinations of 'frac' and 'energy' based measurements work out
         nptest.assert_almost_equal(
             unit_conversion.compute_gross_energy(
-                net[0, :], avail[0, :], curt[0, :], "frac", "frac"
+                net.test1, avail.test1, curtail.test1, "frac", "frac"
             ),
             [1.1111, 1.1494, 1.3333],
             decimal=4,
         )
         nptest.assert_almost_equal(
             unit_conversion.compute_gross_energy(
-                net[0, :], avail[0, :], curt[0, :], "energy", "frac"
+                net.test1, avail.test1, curtail.test1, "energy", "frac"
             ),
             [1.1026, 1.1326, 1.2526],
             decimal=4,
         )
         nptest.assert_almost_equal(
             unit_conversion.compute_gross_energy(
-                net[0, :], avail[0, :], curt[0, :], "frac", "energy"
+                net.test1, avail.test1, curtail.test1, "frac", "energy"
             ),
             [1.1026, 1.1370, 1.3000],
             decimal=4,
         )
         nptest.assert_almost_equal(
             unit_conversion.compute_gross_energy(
-                net[0, :], avail[0, :], curt[0, :], "energy", "energy"
+                net.test1, avail.test1, curtail.test1, "energy", "energy"
             ),
             [1.1000, 1.1300, 1.2500],
             decimal=4,
@@ -61,15 +72,19 @@ class SimpleUnitConversionTests(unittest.TestCase):
 
         # Make sure exceptions are thrown when bad input data is identified
         def func():  # Function to return exception
-            unit_conversion.compute_gross_energy(net[1, :], avail[1, :], curt[1, :], "frac", "frac")
+            unit_conversion.compute_gross_energy(
+                net.test2, avail.test2, curtail.test2, "frac", "frac"
+            )
 
-        with self.assertRaises(Exception):
+        with self.assertRaises(ValueError):
             func()
 
         def func():  # Function to return exception
-            unit_conversion.compute_gross_energy(net[2, :], avail[2, :], curt[2, :], "frac", "frac")
+            unit_conversion.compute_gross_energy(
+                net.test3, avail.test3, curtail.test3, "frac", "frac"
+            )
 
-        with self.assertRaises(Exception):
+        with self.assertRaises(ValueError):
             func()
 
     def test_convert_feet_to_meter(self):


### PR DESCRIPTION
This PR refactors `openoa/utils/unit_conversion.py` to use the interchangeable DataFrame/Series API with minor updates for robustness of methods and earlier failures.