### PR TITLE
Refactor power curve methods for the new DataFrame/Series API and minor speed improvements

### DIFF
--- a/openoa/utils/_converters.py
+++ b/openoa/utils/_converters.py
@@ -202,8 +202,9 @@ def series_to_df(*args: pd.Series, names: list[str] = None) -> tuple[pd.DataFram
         raise TypeError("At least one of the provided values was not a pandas Series")
 
     # Rename the series to the name of the method argument if it doesn't already have name
-    if names is not None:
-        names = [name if el.name is None else el.name for el, name in zip(args, names)]
+    if names is None:
+        names = [None] * len(args)
+    names = [name if el.name is None else el.name for el, name in zip(args, names)]
     args = [el.rename(name) if el.name is None else el for el, name in zip(args, names)]
 
     args = [el.to_frame() for el in args]

--- a/openoa/utils/power_curve/functions.py
+++ b/openoa/utils/power_curve/functions.py
@@ -1,28 +1,42 @@
+"""
+This module holds ready-to-use power curve functions. They take windspeed and power columns as arguments and return a
+python function which can be used to evaluate the power curve at arbitrary locations.
+"""
+from __future__ import annotations
+
+from typing import Callable
+
 import numpy as np
 import pandas as pd
 from pygam import LinearGAM
 from scipy.optimize import differential_evolution
 
-from .parametric_forms import logistic5param
-from .parametric_optimize import least_squares, fit_parametric_power_curve
+from openoa.utils._converters import series_method
+from openoa.utils.power_curve.parametric_forms import logistic5param
+from openoa.utils.power_curve.parametric_optimize import least_squares, fit_parametric_power_curve
 
 
-"""
-This module holds ready-to-use power curve functions. They take windspeed and power columns as arguments and return a
-python function which can be used to evaluate the power curve at arbitrary locations.
-"""
-
-
-def IEC(windspeed_column, power_column, bin_width=0.5, windspeed_start=0, windspeed_end=30.0):
+@series_method(data_cols=["windspeed_col", "power_col"])
+def IEC(
+    windspeed_col: str | pd.Series,
+    power_col: str | pd.Series,
+    bin_width: float = 0.5,
+    windspeed_start: float = 0,
+    windspeed_end: float = 30.0,
+    data: pd.DataFrame = None,
+) -> Callable:
     """
-    Use IEC 61400-12-1-2 method for creating wind-speed binned power curve. Power is set to zero for windspeed values outside of the cutoff range specified by windspeed_start and windspeed_end, inclusive of the endpoints.
+    Use IEC 61400-12-1-2 method for creating a binned wind-speed power curve. Power is set to zero
+    for values outside the cutoff range: [:py:attr:`windspeed_start`, :py:attr:`windspeed_end`].
 
     Args:
-        windspeed_column (:obj:`pandas.Series`): feature column
-        power_column (:obj:`pandas.Series`): response column
-        bin_width(:obj:`float`): width of windspeed bin, default is 0.5 m/s according to standard
-        windspeed_start(:obj:`float`): left edge of first windspeed bin
-        windspeed_end(:obj:`float`): right edge of last windspeed bin
+        windspeed_column(:obj:`str` | `pandas.Series`): Windspeed data, or the name of the column in
+            :py:attr:`data`.
+        power_column(:obj:`str` | `pandas.Series`): Power data, or the name of the column in
+            :py:attr:`data`.
+        bin_width(:obj:`float`): Width of windspeed bin. Defaults to 0.5 m/s, per the standard.
+        windspeed_start(:obj:`float`): Left edge of first windspeed bin. Defaults to 0.0.
+        windspeed_end(:obj:`float`): Right edge of last windspeed bin. Defaults to 30.0
 
     Returns:
         :obj:`function`: Python function of type (Array[float] -> Array[float]) implementing the power curve.
@@ -38,8 +52,8 @@ def IEC(windspeed_column, power_column, bin_width=0.5, windspeed_start=0, windsp
 
     # Compute the mean of each bin and set corresponding P_bin
     for ibin in range(0, len(bins) - 1):
-        indices = (windspeed_column >= bins[ibin]) & (windspeed_column < bins[ibin + 1])
-        P_bin[ibin] = power_column.loc[indices].mean()
+        indices = (windspeed_col >= bins[ibin]) & (windspeed_col < bins[ibin + 1])
+        P_bin[ibin] = power_col.loc[indices].mean()
 
     # Linearly interpolate any missing bins
     P_bin = pd.Series(data=P_bin).interpolate(method="linear").bfill().values
@@ -57,7 +71,10 @@ def IEC(windspeed_column, power_column, bin_width=0.5, windspeed_start=0, windsp
     return pc_iec
 
 
-def logistic_5_parametric(windspeed_column, power_column):
+@series_method(data_cols=["windspeed_col", "power_col"])
+def logistic_5_parametric(
+    windspeed_col: str | pd.Series, power_col: str | pd.Series, data: pd.DataFrame = None
+) -> Callable:
     """
     The present implementation follows the filtering method reported in:
 

--- a/openoa/utils/power_curve/functions.py
+++ b/openoa/utils/power_curve/functions.py
@@ -30,16 +30,18 @@ def IEC(
     for values outside the cutoff range: [:py:attr:`windspeed_start`, :py:attr:`windspeed_end`].
 
     Args:
-        windspeed_column(:obj:`str` | `pandas.Series`): Windspeed data, or the name of the column in
+        windspeed_col(:obj:`str` | `pandas.Series`): Windspeed data, or the name of the column in
             :py:attr:`data`.
-        power_column(:obj:`str` | `pandas.Series`): Power data, or the name of the column in
+        power_col(:obj:`str` | `pandas.Series`): Power data, or the name of the column in
             :py:attr:`data`.
         bin_width(:obj:`float`): Width of windspeed bin. Defaults to 0.5 m/s, per the standard.
         windspeed_start(:obj:`float`): Left edge of first windspeed bin. Defaults to 0.0.
         windspeed_end(:obj:`float`): Right edge of last windspeed bin. Defaults to 30.0
+        data(:obj:`pandas.DataFrame`, optional): a pandas DataFrame containing
+            :py:attr:`windspeed_col` and :py:attr:`power_col`. Defaults to None.
 
     Returns:
-        :obj:`function`: Python function of type (Array[float] -> Array[float]) implementing the power curve.
+        :obj:`Callable`: Python function of type (Array[float] -> Array[float]) implementing the power curve.
 
     """
 
@@ -75,7 +77,11 @@ def IEC(
 def logistic_5_parametric(
     windspeed_col: str | pd.Series, power_col: str | pd.Series, data: pd.DataFrame = None
 ) -> Callable:
-    """
+    """In this case, the function fits the 5 parameter logistics function to observed data via a
+    least-squares optimization (i.e. minimizing the sum of the squares of the residual between the
+    points as evaluated by the parameterized function and the points of observed data).
+
+    Extra:
     The present implementation follows the filtering method reported in:
 
         M. Yesilbudaku Partitional clustering-based outlier detection
@@ -93,26 +99,23 @@ def logistic_5_parametric(
         A comprehensive review on wind turbine power curve modeling techniques
         Renew. Sust. Energy Rev., 30 (2014), pp. 452-460
 
-    In this case, the function fits the 5 parameter logistics function to
-    observed data via a least-squares optimization (i.e. minimizing the sum of
-    the squares of the residual between the points as evaluated by the
-    parameterized function and the points of observed data).
 
 
     Args:
-        windspeed_column (:obj:`pandas.Series`): feature column
-        power_column (:obj:`pandas.Series`): response column
-        bin_width(:obj:`float`): width of windspeed bin, default is 0.5 m/s according to standard
-        windspeed_start(:obj:`float`): left edge of first windspeed bin
-        windspeed_end(:obj:`float`): right edge of last windspeed bin
+        windspeed_col(:obj:`str` | `pandas.Series`): Windspeed data, or the name of the column in
+            :py:attr:`data`.
+        power_col(:obj:`str` | `pandas.Series`): Power data, or the name of the column in
+            :py:attr:`data`.
+        data(:obj:`pandas.DataFrame`, optional): a pandas DataFrame containing
+            :py:attr:`windspeed_col` and :py:attr:`power_col`. Defaults to None.
 
     Returns:
         :obj:`function`: Python function of type (Array[float] -> Array[float]) implementing the power curve.
 
     """
     return fit_parametric_power_curve(
-        windspeed_column,
-        power_column,
+        windspeed_col,
+        power_col,
         curve=logistic5param,
         optimization_algorithm=differential_evolution,
         cost_function=least_squares,

--- a/openoa/utils/power_curve/functions.py
+++ b/openoa/utils/power_curve/functions.py
@@ -187,7 +187,13 @@ def gam_3param(
     model = LinearGAM(n_splines=n_splines).fit(X, y)
 
     # Wrap the prediction function in a closure to pack input variables
-    def predict(windspeed_col, wind_direction_col, air_density_col):
+    @dataframe_method(data_cols=["windspeed_col", "wind_direction_col", "air_density_col"])
+    def predict(
+        windspeed_col: str | pd.Series,
+        wind_direction_col: str | pd.Series,
+        air_density_col: str | pd.Series,
+        data: pd.DataFrame = None,
+    ):
         X = data[[windspeed_col, wind_direction_col, air_density_col]]
         return model.predict(X)
 

--- a/openoa/utils/power_curve/functions.py
+++ b/openoa/utils/power_curve/functions.py
@@ -123,21 +123,31 @@ def logistic_5_parametric(
     )
 
 
-def gam(windspeed_column, power_column, n_splines=20):
+@series_method(data_cols=["windspeed_col", "power_col"])
+def gam(
+    windspeed_col: str | pd.Series,
+    power_col: str | pd.Series,
+    n_splines: int = 20,
+    data: pd.DataFrame = None,
+) -> Callable:
     """
-    Use a generalized additive model to fit power to wind speed.
+    Use the generalized additive model, :py:class:`pygam.LinearGAM` to fit power to wind speed.
 
     Args:
-        windspeed_column (:obj:`pandas.Series`): Wind speed feature column
-        power_column (:obj:`pandas.Series`): Power response column
+        windspeed_col(:obj:`str` | `pandas.Series`): Windspeed data, or the name of the column in
+            :py:attr:`data`.
+        power_col(:obj:`str` | `pandas.Series`): Power data, or the name of the column in
+            :py:attr:`data`.
         n_splines (:obj:`int`): number of splines to use in the fit
+        data(:obj:`pandas.DataFrame`, optional): a pandas DataFrame containing
+            :py:attr:`windspeed_col` and :py:attr:`power_col`. Defaults to None.
 
     Returns:
-        :obj:`function`: Python function of type (Array[float] -> Array[float]) implementing the power curve.
+        :obj:`Callable`: Python function of type (Array[float] -> Array[float]) implementing the power curve.
 
     """
     # Fit the model
-    return LinearGAM(n_splines=n_splines).fit(windspeed_column.values, power_column.values).predict
+    return LinearGAM(n_splines=n_splines).fit(windspeed_col.values, power_col.values).predict
 
 
 def gam_3param(windspeed_column, winddir_column, airdens_column, power_column, n_splines=20):

--- a/openoa/utils/power_curve/parametric_forms.py
+++ b/openoa/utils/power_curve/parametric_forms.py
@@ -1,6 +1,3 @@
-import numpy as np
-
-
 """
 Power Curves
 
@@ -16,26 +13,44 @@ ref: https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimiz
 
 """
 
+from __future__ import annotations
 
-def _power_curve(x, a, b, c, d, g):
-    """Applies the power curve function at each point in x."""
-    return [d + (a - d) / (1 + (xx / c) ** b) ** g for xx in x]
+import numpy as np
+import pandas as pd
 
 
-def logistic5param(x, a, b, c, d, g):
+def _power_curve(x: np.ndarray | pd.Series, a: float, b: float, c: float, d: float, g: float):
+    """The actual power curve implementation.
+
+    Args:
+        x(:obj:`numpy.ndarray` | `pandas.Series`): input data
+        a(:obj:`float`): the minimum value asymptote
+        b(:obj:`float`): steepness of the curve
+        c(:obj:`float`): the point of inflection
+        d(:obj:`float`): the maximum value asymptote
+        g(:obj:`float`): asymmetry of the curve
+
+    Returns:
+        (:obj:`numpy.ndarray`): The converted power data.
+    """
+    if isinstance(x, pd.Series):
+        x = x.values
+    return d + (a - d) / (1 + (x / c) ** b) ** g
+
+
+def logistic5param(x: np.ndarray | pd.Series, a: float, b: float, c: float, d: float, g: float):
     """Create and return a 5 parameter logistic function
 
     Args:
-        x(numpy.array): input data
-        a(float): the minimum value asymptote
-        b(float): steepness of the curve
-        c(float): the point of inflection
-        d(float): the maximum value asymptote
-        g(float): asymmetry of the curve
+        x(:obj:`numpy.ndarray` | `pandas.Series`): Input data.
+        a(:obj:`float`): The minimum value asymptote.
+        b(:obj:`float`): Steepness of the curve.
+        c(:obj:`float`): The point of inflection.
+        d(:obj:`float`): The maximum value asymptote.
+        g(:obj:`float`): Asymmetry of the curve.
 
     Returns:
         Function[numpy.ndarray[real]] -> numpy.ndarray[real]
-        Function[pandas.Series[real]] -> pandas.Series[real]
 
     """
 
@@ -53,22 +68,30 @@ def logistic5param(x, a, b, c, d, g):
     return res
 
 
-def logistic5param_capped(x, a, b, c, d, g, lower, upper):
+def logistic5param_capped(
+    x: np.ndarray | pd.Series,
+    a: float,
+    b: float,
+    c: float,
+    d: float,
+    g: float,
+    lower: float,
+    upper: float,
+):
     """Create and return a capped 5 parameter logistic function whose output is capped by lower and upper bounds.
 
     Args:
-        x(numpy.array): input data
-        a(float): the minimum value asymptote
-        b(float): steepness of the curve
-        c(float): the point of inflection
-        d(float): the maximum value asymptote
-        g(float): asymmetry of the curve
-        lower(Number): Input values below this number are set to this number.
-        upper(Number): Input values above this number are set to this number.
+        x(:obj:`numpy.ndarray` | `pandas.Series`): Input data.
+        a(:obj:`float`): The minimum value asymptote.
+        b(:obj:`float`): Steepness of the curve.
+        c(:obj:`float`): The point of inflection.
+        d(:obj:`float`): The maximum value asymptote.
+        g(:obj:`float`): Asymmetry of the curve.
+        lower(:obj:`float`): Input values below this number are set to this number.
+        upper(:obj:`float`): Input values above this number are set to this number.
 
     Returns:
         Function[numpy.ndarray[real]] -> numpy.ndarray[real]
-        Function[pandas.Series[real]] -> pandas.Series[real]
 
     """
     return _cap(logistic5param(x, a, b, c, d, g), lower, upper)
@@ -81,9 +104,9 @@ Helpers for Power Curve
 
 def _cap(y, lower, upper):
     if type(y) is np.ndarray:
-        y[y < lower] = lower
-        y[y > upper] = upper
+        y = np.where(y < lower, lower, y)
+        y = np.where(y > upper, upper, y)
     else:
-        y.loc[y < lower] = lower
-        y.loc[y > upper] = upper
+        y = y.where(y > lower, lower)
+        y = y.where(y < upper, upper)
     return y

--- a/test/unit/test_power_curve_toolkit.py
+++ b/test/unit/test_power_curve_toolkit.py
@@ -3,6 +3,7 @@ import unittest
 import numpy as np
 import pandas as pd
 from numpy import testing as nptest
+
 from openoa.utils import power_curve
 from openoa.utils.power_curve.parametric_forms import logistic5param, logistic5param_capped
 
@@ -92,7 +93,7 @@ class TestPowerCurveFunctions(unittest.TestCase):
 
     def test_gam(self):
         # Create test data using logistic5param form
-        curve = power_curve.gam(windspeed_column=self.x, power_column=self.y, n_splines=20)
+        curve = power_curve.gam(windspeed_col=self.x, power_col=self.y, n_splines=20)
         y_pred = curve(self.x)
         # Does the spline-fit power curve match the test data?
         nptest.assert_allclose(
@@ -101,13 +102,13 @@ class TestPowerCurveFunctions(unittest.TestCase):
 
     def test_3paramgam(self):
         # Create test data using logistic5param form
-        winddir = np.random.random(100)
-        airdens = np.random.random(100)
+        winddir = pd.Series(np.random.random(100), name="winddir")
+        airdens = pd.Series(np.random.random(100), name="airdens")
         curve = power_curve.gam_3param(
-            windspeed_column=self.x,
-            winddir_column=winddir,
-            airdens_column=airdens,
-            power_column=self.y,
+            windspeed_col=self.x,
+            wind_direction_col=winddir,
+            air_density_col=airdens,
+            power_col=self.y,
             n_splines=20,
         )
         y_pred = curve(self.x, winddir, airdens)


### PR DESCRIPTION
This PR refactors each module in `openoa/utils/power_curve/` for the following:
- Public facing methods use the new dataframe/series API
- Minor speed improvements under the hood
- Better documentation and type hinting throughout


Additionally:
- A bug in `examples/project_ENGIE.py` is fixed in how a boolean series is used for indexing because of odd behavior with 1-column dataframes having a 1-column series boolean filter
- The dataframe/series converters also now have a flag that passes through the column name arguments in case Series that need to be concatenated don't have column names, so they get renamed to the argument's name