### PR TITLE
Incorrect version specification for some dependencies in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ REQUIRED = [
     "scipy>=1.1.0",
     "statsmodels>=0.11",
     "tqdm>=4.28.1",
-    "matplotlib>=3.6.*",
-    "bokeh>=2.4.*",
+    "matplotlib>=3.6",
+    "bokeh>=2.4",
     "attrs>=22",
     "pytz",
     "pyspark",  # TODO: confirm if options required [sql] or [pandas_on_spark]
@@ -35,7 +35,7 @@ TESTS = ["pytest>=5.4.2", "pytest-cov>=2.8.1"]
 EXTRAS = {
     "docs": [
         "ipython==8.5.*",
-        "m2r2>=0.3.*",
+        "m2r2>=0.3",
         "Sphinx>=5.0",
         "pydata-sphinx-theme==0.10.*",
         "nbmerge==0.0.4",


### PR DESCRIPTION
**Summary:**
This pull request should fix the "extras_requires" error during pip install by modifying some version clauses in our setup.py file to use the inclusive ordered comparison.

**Observed Behavior**
Error observed on pip install: `error in OpenOA setup command: 'extras_require' must be a dictionary whose values are strings or lists of strings containing valid project/version requirement specifiers.`

**Explaination**
We had been incorrectly specifying some of our dependencies in setup.py. Past version of pip must have been more forgiving.

Example of incorrect version clause: `matplotlib>=3.6.*`
Instead, use:
-  The similar release clause `matplotlib~=3.6`
-  Inclusive ordered comparison `matplotlib>=3.6`

See: https://github.com/pypa/setuptools/issues/3801

**Changes**
In this pull request I modify the version specifiers in OpenOA to use the inclusive ordered comparison.
