### PR TITLE
Excluding examples module from setup.py packages list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ setup(
     author="NREL PRUF OA Team",
     author_email="openoa@nrel.gov",
     url="https://github.com/NREL/OpenOA",
-    packages=find_packages(exclude=["test"]),
+    packages=find_packages(exclude=["test", "examples"]),
     include_package_data=True,
     install_requires=REQUIRED,
     extras_require=EXTRAS,


### PR DESCRIPTION
I discovered that the "examples" module was being installed as a separate package with OpenOA. This pollutes the user's environment and was not expected behavior to me. The culprit is this find_packages() function, which automatically includes all packages in the source tree unless specifically excluded.

Changes:
- Added "examples" to the exclusion list.