### PR TITLE
Bug Fix: Asset table operations

### DIFF
--- a/openoa/plant.py
+++ b/openoa/plant.py
@@ -1252,7 +1252,9 @@ class PlantData:
 
         # Maintain v2 compatibility of np.inf for the diagonal
         distance = distance + distance.values.T - np.diag(np.diag(distance.values))
-        np.fill_diagonal(distance.values, np.inf)
+        distance_array = distance.values
+        np.fill_diagonal(distance_array, np.inf)
+        distance.loc[:, :] = distance_array
         self.asset_distance_matrix = distance
 
     def turbine_distance_matrix(self, turbine_id: str = None) -> pd.DataFrame:
@@ -1330,7 +1332,9 @@ class PlantData:
             + np.triu((direction.values - 180.0) % 360.0, 1).T
             - np.diag(np.diag(direction.values))
         )
-        np.fill_diagonal(direction.values, np.inf)
+        direction_array = direction.values
+        np.fill_diagonal(direction_array, np.inf)
+        direction.loc[:, :] = direction_array
         self.asset_direction_matrix = direction
 
     def turbine_direction_matrix(self, turbine_id: str = None) -> pd.DataFrame:
@@ -1443,7 +1447,7 @@ class PlantData:
                 'Invalid freestream method. Currently, "sector" and "IEC" are supported.'
             )
 
-        return list(self.asset.index[freestream_indices])
+        return list(self.asset.loc[self.asset["type"] == "turbine"].index[freestream_indices])
 
     @logged_method_call
     def calculate_nearest_neighbor(


### PR DESCRIPTION
This small pull request fixes a few issues I found when calling the `get_freestream_turbines` method in `PlantData` and running wake loss analyses for a wind plant with both turbine and tower assets.

1. In `calculate_asset_distance_matrix` and `calculate_asset_direction_matrix`, the diagonals of the matrices weren't getting set to np.inf like we expected. This could possibly be because of a new pandas version. 
2. An error would appear in `get_freestream_turbines` when there are tower assets in addition to turbine assets. Specifically, `self.asset.index` includes both turbine and tower indices, but `freestream_indices` only includes boolean values corresponding to turbines, so the dimensions didn't match in the return statement.  