### PR TITLE
Fix `pyproject.toml` Specificaiton for Expected Installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file. If you make a notable change to the project, please add a line describing the change to the "unreleased" section. The maintainers will make an effort to keep the [Github Releases](https://github.com/NREL/OpenOA/releases) page up to date with this changelog. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## v3.1.1 - 2024-04-05
+
+- Patches `pyproject.toml`'s package data specification to include openoa in the valid packages to install.
+
 ## v3.1 - 2024-03-14
 
 - Updated compatibility with Pandas datetime offsets. All uppercase offset strings representing

--- a/openoa/__init__.py
+++ b/openoa/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.1.0"
+__version__ = "3.1.1"
 """
 When bumping version, please be sure to also update parameters in sphinx/conf.py
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,6 @@
 requires = ["setuptools", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
 
-[metadata]
-version = "attr: openoa.__version__"
-
 [project]
 name = "OpenOA"
 dynamic = ["version"]
@@ -103,7 +100,7 @@ all = ["openoa[develop,docs,examples]"]
 include-package-data = true
 
 [tool.setuptools.packages.find]
-include = ["test", "examples"]
+include = ["openoa", "test", "examples"]
 
 [tool.setuptools.dynamic]
 version = {attr = "openoa.__version__"}


### PR DESCRIPTION
This fixes an issue with porting the project over to using `pyproject.toml` where the actual package isn't included in the package data.