### PR TITLE
Typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ is also allowed).
 - `develop`: for linting, automated formatting, and testing
 - `docs`: for building the documentation
 - `examples`: for the full Jupyter Lab suite (also contains `reanalysis` and `nrel-wind`)
-- `renalysis`: for accessing and processing MERRA2 and ERA5 data
+- `reanalysis`: for accessing and processing MERRA2 and ERA5 data
 - `nrel-wind`: for accessing the NREL WIND Toolkit
 - `all`: for the complete dependency stack
 


### PR DESCRIPTION
Fixed typo, `renalysis` -> `reanalysis` in the install instructions that could cause problems for users.