### PR TITLE
Patch Internal Inconsistency with PyGAM and SciPy 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 All notable changes to this project will be documented in this file. If you make a notable change to the project, please add a line describing the change to the "unreleased" section. The maintainers will make an effort to keep the [Github Releases](https://github.com/NREL/OpenOA/releases) page up to date with this changelog. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Unreleased - TBD
+## v3.1.3 - 2025 01-30
 
+- Pin SciPy to >= 1.7 and <1.14 to avoid an incompatibility error with PyGAM.
 - Updates the Anaconda recommendation to alert users to the fact that Anaconda is no longer
 technically free, and so commercial users should consider Miniforge or Miniconda installations.
 

--- a/openoa/__init__.py
+++ b/openoa/__init__.py
@@ -1,4 +1,5 @@
-__version__ = "3.1.1"
+__version__ = "3.1.2"
+
 """
 When bumping version, please be sure to also update parameters in sphinx/conf.py
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "numpy>=1.24",
     "pandas>=2.2",
     "pygam>=0.9.0",
-    "scipy>=1.7",
+    "scipy>=1.7,<1.14",
     "statsmodels>=0.11; python_version<'3.11'",
     "statsmodels>=0.13.3; python_version=='3.11'",
     "tqdm>=4.28.1",


### PR DESCRIPTION
This PR pins scipy to less than v1.14 to resolve #303.