### PR TITLE
Enhancement: Add flexibility to the Monte Carlo analysis PlantData initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 # Changelog
 All notable changes to this project will be documented in this file. If you make a notable change to the project, please add a line describing the change to the "unreleased" section. The maintainers will make an effort to keep the [Github Releases](https://github.com/NREL/OpenOA/releases) page up to date with this changelog. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+- Features and updates:
+  - `MonteCarloAEP` updates
+    - Add an `n_jobs` input to the Monte Carlo AEP method to allow for the underlying models to be
+      parallelized during each iteration for faster ML model computation.
+    - Add an `apply_iav` input to the Monte Carlo AEP analysis method to toggle the addition of the
+      IAV factor at the end of the analysis.
+    - Add a `progress_bar` flag to `MonteCarloAEP.run()` to allow for turing on or off the
+      simulation's default progress bar.
+  - Implement missing `compute_wind_speed` in `openoa/utils/met_data_processing.py` and apply it to
+    the `PlantData` reanalysis validation steps in place of the manual calculation.
+- Fixes:
+  - Add a default value for `PlantData`'s `asset_distance_matrix` and `asset_direction_matrix` to
+    ensure projects not utilizing location data are compatible.
+
 ## v3.1.3 - 2025-01-31
 
 - Pin SciPy to >= 1.7 and <1.14 to avoid an incompatibility error with PyGAM.

--- a/openoa/plant.py
+++ b/openoa/plant.py
@@ -443,8 +443,8 @@ class PlantData:
         default={"missing": {}, "dtype": {}, "frequency": {}, "attributes": []}, init=False
     )
     eia: dict = field(default={}, init=False)
-    asset_distance_matrix: pd.DataFrame = field(init=False)
-    asset_direction_matrix: pd.DataFrame = field(init=False)
+    asset_distance_matrix: pd.DataFrame = field(init=False, default=pd.DataFrame([]))
+    asset_direction_matrix: pd.DataFrame = field(init=False, default=pd.DataFrame([]))
 
     def __attrs_post_init__(self):
         """Post-initialization hook."""

--- a/openoa/plant.py
+++ b/openoa/plant.py
@@ -1043,7 +1043,7 @@ class PlantData:
 
             ws = col_map["WMETR_HorWdSpd"]
             if ws not in df and has_u_v:
-                df[ws] = np.sqrt(df[u].values ** 2 + df[v].values ** 2)
+                df[ws] = met.compute_wind_speed(df[u], df[v]).values
 
             wd = col_map["WMETR_HorWdDir"]
             if wd not in df and has_u_v:

--- a/openoa/utils/machine_learning_setup.py
+++ b/openoa/utils/machine_learning_setup.py
@@ -107,6 +107,9 @@ class MachineLearningSetup:
     random_search: Any = field(init=False)
     opt_hyp: Any = field(init=False)
     opt_model: Any = field(init=False)
+    n_jobs: int | None = field(
+        default=None,
+    )
 
     def __attrs_post_init__(self):
         """
@@ -167,6 +170,7 @@ class MachineLearningSetup:
         n_iter_search: int = 20,
         report: bool = True,
         verbose: int = 0,
+        n_jobs: int | None = None,
     ) -> None:
         """
         Optimize hyperparameters through cross-validation
@@ -186,6 +190,9 @@ class MachineLearningSetup:
                 - >1 : the computation time for each fold and parameter candidate is displayed;
                 - >2 : the score is also displayed;
                 - >3 : the fold and candidate parameter indexes are also displayed together with the starting time of the computation.
+            n_jobs(:obj:`int`): The number of jobs to use for the computation in the scikit-learn model.
+                This will only provide speedup in case of sufficiently large problems.``None`` means 1
+                unless in a :obj:`joblib.parallel_backend` context. ``-1`` means using all processors.
 
         Returns:
             (none)
@@ -199,6 +206,7 @@ class MachineLearningSetup:
             scoring=self.my_scorer,
             verbose=0,
             return_train_score=True,
+            n_jobs=self.n_jobs,
         )
         # Fit the model to each combination of hyperparmeters
         self.random_search.fit(X, y)

--- a/openoa/utils/met_data_processing.py
+++ b/openoa/utils/met_data_processing.py
@@ -71,6 +71,27 @@ def circular_mean(x: pd.DataFrame | pd.Series | np.ndarray, axis: int = 0):
 
 
 @series_method(data_cols=["u", "v"])
+def compute_wind_speed(
+    u: pd.Series | str, v: pd.Series | str, data: pd.DataFrame = None
+) -> pd.Series:
+    """Compute the wind speed from the u and v components. This function should only be used for
+    higher resolution wind data, otherwise the resulting wind speed will be lower than expected.
+
+    Args:
+    u(:obj:`pandas.Series` | :obj:`str`): A pandas DataFrame or Series, or a numpy array
+        containing the u-component of the wind speed, in m/s.
+    v(pd.Series | str): A pandas DataFrame or Series, or a numpy array containing the v-component
+        of the wind speed, in m/s.
+    data(:obj:`pandas.Series` | :obj:`str`): The pandas ``DataFrame`` containg the columns
+        :py:attr:`u` and :py:attr:`v`.
+
+    Returns:
+        :obj:`pandas.Series`: wind speed, in m/s.
+    """
+    return np.sqrt(u**2 + v**2)
+
+
+@series_method(data_cols=["u", "v"])
 def compute_wind_direction(
     u: pd.Series | str, v: pd.Series | str, data: pd.DataFrame = None
 ) -> pd.Series:


### PR DESCRIPTION
This PR addresses a series of small features and fixes from the HVS2 work as outlined below.

- `MonteCarloAEP`
  - `n_jobs` to enable parallelization of each iteration's model
  - `apply_iav` to toggle the addition of the interannual variability at the end of the analysis.
  - `run::progress_bar` to toggle the use of a progress bar during the analysis. When running many models, turning off the progress bar for each iteration of a parameter sweep greatly reduces the amount of outputs to scroll through.
- Implements and applies a wind speed calculation from the u and v components in place of a manual calculation.
- Adds default empty data frames for the `PlantData`'s `asset_distance_matrix` and `asset_direction_matrix` values. Without the defaults, plants not utilizing location data end up failing at analysis time since no data is able to be passed.