### PR TITLE
Enhancement: Update supported Python versions

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [3.9, 3.11]
+        python-version: [3.9, 3.12]
 
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file. If you make a notable change to the project, please add a line describing the change to the "unreleased" section. The maintainers will make an effort to keep the [Github Releases](https://github.com/NREL/OpenOA/releases) page up to date with this changelog. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+- Deprecate Python 3.8 support and enable 3.12 support.
+
 ## v3.1.3 - 2025-01-31
 
 - Pin SciPy to >= 1.7 and <1.14 to avoid an incompatibility error with PyGAM.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ effort more broadly,** please use citation [^1], which is provided below in BibT
 
 ### Requirements
 
-- Python 3.8-3.11 with pip.
+- Python 3.9-3.12 with pip.
 
 We strongly recommend using the Anaconda Python distribution and creating a new conda environment
 for OpenOA. You can download Anaconda through
@@ -163,10 +163,6 @@ is also allowed).
 - `reanalysis`: for accessing and processing MERRA2 and ERA5 data
 - `nrel-wind`: for accessing the NREL WIND Toolkit
 - `all`: for the complete dependency stack
-
-> **Important**
-> If using Python 3.11, install `openoa` only, then reinstall adding the modifiers to reduce
-> the amount of time it takes for pip to resolve the dependency stack.
 
 #### Common Installation Issues
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 authors = [{name = "NREL PRUF OA Team", email = "openoa@nrel.gov"}]
 readme = {file = "README.md", content-type = "text/markdown"}
 description = "A package for collecting and assigning wind turbine metrics"
-requires-python = ">=3.8, <3.12"
+requires-python = ">=3.9, <3.13"
 license = {file = "LICENSE.txt"}
 dependencies = [
     "scikit-learn>=1.0",
@@ -21,7 +21,7 @@ dependencies = [
     "pygam>=0.9.0",
     "scipy>=1.7,<1.14",
     "statsmodels>=0.11; python_version<'3.11'",
-    "statsmodels>=0.13.3; python_version=='3.11'",
+    "statsmodels>=0.13.3; python_version>='3.11'",
     "tqdm>=4.28.1",
     "matplotlib>=3.6",
     "bokeh>=3.3",
@@ -50,10 +50,10 @@ classifiers = [  # https://pypi.org/classifiers/
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",

--- a/sphinx/getting_started/index.rst
+++ b/sphinx/getting_started/index.rst
@@ -32,10 +32,6 @@ Source
 Additional Dependencies
 -----------------------
 
-.. important::
-    If using Python 3.11, install ``openoa`` only, then reinstall adding the modifiers to reduce
-    the amount of time it takes for pip to resolve the dependency stack.
-
 Whether installing from PyPI or source, any combination of the following can be used to install
 additional dependencies. For example, the examples requirements can be installed using
 `pip install "openoa[examples]"`.

--- a/sphinx/getting_started/install.rst
+++ b/sphinx/getting_started/install.rst
@@ -31,10 +31,6 @@ at the same time with the following.
 
     pip install "OpenOA[develop]"
 
-.. important::
-    If using Python 3.11, install ``openoa`` only, then reinstall adding the modifiers to reduce
-    the amount of time it takes for pip to resolve the dependency stack.
-
 Additional options:
 - `develop`: for linting, automated formatting, and testing
 - `docs`: for building the documentation


### PR DESCRIPTION
This PR updates Python support from 3.8 through 3.11 to 3.9 through 3.12. Additionally, the note stemming from early 3.11 support has been removed as pip's resolver is much better than when the warning was written.

The only thing stopping OpenOA from supporting 3.13 is pyGAM, which has not had a new version release since February 2024. This library does not seem to have an immediate replacement, so further work must be done if pyGAM becomes deprecated.